### PR TITLE
kontrol: Pass a pointer to KontrolQuery where possible.

### DIFF
--- a/kitectl/command/query.go
+++ b/kitectl/command/query.go
@@ -64,7 +64,7 @@ func (c *Query) Run(args []string) int {
 	flags.StringVar(&query.ID, "id", "", "")
 	flags.Parse(args)
 
-	result, err := c.KiteClient.GetKites(query)
+	result, err := c.KiteClient.GetKites(&query)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1

--- a/kontrol/kontrol.go
+++ b/kontrol/kontrol.go
@@ -243,8 +243,7 @@ func (k *Kontrol) register(r *kite.Client, kiteURL string) error {
 		return err
 	}
 
-	kontrolQuery := r.Query()
-	queryKey, err := GetQueryKey(&kontrolQuery)
+	queryKey, err := GetQueryKey(r.Query())
 	if err != nil {
 		return err
 	}

--- a/kontrol/kontrol_test.go
+++ b/kontrol/kontrol_test.go
@@ -163,7 +163,7 @@ func TestMultiple(t *testing.T) {
 
 					time.Sleep(time.Millisecond * time.Duration(rand.Intn(500)))
 
-					query := protocol.KontrolQuery{
+					query := &protocol.KontrolQuery{
 						Username:    conf.Username,
 						Environment: conf.Environment,
 						Name:        "example" + strconv.Itoa(rand.Intn(kiteNumber)),
@@ -207,7 +207,7 @@ func TestGetKites(t *testing.T) {
 	}
 	defer m.Close()
 
-	query := protocol.KontrolQuery{
+	query := &protocol.KontrolQuery{
 		Username:    conf.Username,
 		Environment: conf.Environment,
 		Name:        testName,
@@ -298,7 +298,7 @@ func TestKontrol(t *testing.T) {
 	exp2Kite := kite.New("exp2", "0.0.1")
 	exp2Kite.Config = conf.Copy()
 
-	query := protocol.KontrolQuery{
+	query := &protocol.KontrolQuery{
 		Username:    exp2Kite.Kite().Username,
 		Environment: exp2Kite.Kite().Environment,
 		Name:        "mathworker",

--- a/kontrolclient.go
+++ b/kontrolclient.go
@@ -124,7 +124,7 @@ func (k *Kite) SetupKontrolClient() error {
 
 // WatchKites watches for Kites that matches the query. The onEvent functions
 // is called for current kites and every nekite event.
-func (k *Kite) WatchKites(query protocol.KontrolQuery, onEvent EventHandler) (*Watcher, error) {
+func (k *Kite) WatchKites(query *protocol.KontrolQuery, onEvent EventHandler) (*Watcher, error) {
 	if err := k.SetupKontrolClient(); err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func (k *Kite) WatchKites(query protocol.KontrolQuery, onEvent EventHandler) (*W
 		return nil, err
 	}
 
-	return k.newWatcher(watcherID, &query, onEvent), nil
+	return k.newWatcher(watcherID, query, onEvent), nil
 }
 
 func (k *Kite) eventCallbackHandler(onEvent EventHandler) dnode.Function {
@@ -156,7 +156,7 @@ func (k *Kite) eventCallbackHandler(onEvent EventHandler) dnode.Function {
 	})
 }
 
-func (k *Kite) watchKites(query protocol.KontrolQuery, onEvent EventHandler) (watcherID string, err error) {
+func (k *Kite) watchKites(query *protocol.KontrolQuery, onEvent EventHandler) (watcherID string, err error) {
 	args := protocol.GetKitesArgs{
 		Query:         query,
 		WatchCallback: k.eventCallbackHandler(onEvent),
@@ -188,7 +188,7 @@ func (k *Kite) watchKites(query protocol.KontrolQuery, onEvent EventHandler) (wa
 // contains Ready to connect Client instances. The caller must connect
 // with Client.Dial() before using each Kite. An error is returned when no
 // kites are available.
-func (k *Kite) GetKites(query protocol.KontrolQuery) ([]*Client, error) {
+func (k *Kite) GetKites(query *protocol.KontrolQuery) ([]*Client, error) {
 	if err := k.SetupKontrolClient(); err != nil {
 		return nil, err
 	}
@@ -426,7 +426,7 @@ func (k *Kite) RegisterToProxy(registerURL *url.URL, query *protocol.KontrolQuer
 				Key:  k.Config.KiteKey,
 			}
 		} else {
-			kites, err := k.GetKites(*query)
+			kites, err := k.GetKites(query)
 			if err != nil {
 				k.Log.Error("Cannot get Proxy kites from Kontrol: %s", err.Error())
 				time.Sleep(proxyRetryDuration)

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -15,12 +15,12 @@ var ErrNotFound = errors.New("not found")
 // Pool is helper for staying connected to every kite in a query.
 type Pool struct {
 	localKite  *kite.Kite
-	query      protocol.KontrolQuery
+	query      *protocol.KontrolQuery
 	kites      map[string]*kite.Client
 	sync.Mutex // protects Kites map
 }
 
-func New(k *kite.Kite, q protocol.KontrolQuery) *Pool {
+func New(k *kite.Kite, q *protocol.KontrolQuery) *Pool {
 	return &Pool{
 		localKite: k,
 		query:     q,

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -36,7 +36,7 @@ func TestPool(t *testing.T) {
 	foo := kite.New("foo", "1.0.0")
 	foo.Config = conf.Copy()
 
-	query := protocol.KontrolQuery{
+	query := &protocol.KontrolQuery{
 		Username:    conf.Username,
 		Environment: conf.Environment,
 		Name:        "bar",

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -53,9 +53,9 @@ func (k Kite) String() string {
 		"/" + k.ID
 }
 
-// Query() returns a KontrolQuery struct.
-func (k *Kite) Query() KontrolQuery {
-	return KontrolQuery{
+// Query() returns a pointer to KontrolQuery struct.
+func (k *Kite) Query() *KontrolQuery {
+	return &KontrolQuery{
 		Username:    k.Username,
 		Environment: k.Environment,
 		Name:        k.Name,
@@ -110,7 +110,7 @@ type RegisterResult struct {
 }
 
 type GetKitesArgs struct {
-	Query         KontrolQuery    `json:"query"`
+	Query         *KontrolQuery   `json:"query"`
 	WatchCallback dnode.Function  `json:"watchCallback"`
 	Who           json.RawMessage `json:"who"`
 }

--- a/reverseproxy/reverseproxy_test.go
+++ b/reverseproxy/reverseproxy_test.go
@@ -73,7 +73,7 @@ func TestWebSocketProxy(t *testing.T) {
 
 	// now search for a proxy from kontrol
 	color.Green("BackendKite is searching proxy from kontrol")
-	kites, err := backendKite.GetKites(protocol.KontrolQuery{
+	kites, err := backendKite.GetKites(&protocol.KontrolQuery{
 		Username:    "testuser",
 		Environment: config.DefaultConfig.Environment,
 		Name:        Name,
@@ -118,7 +118,7 @@ func TestWebSocketProxy(t *testing.T) {
 	foreignKite.Config = conf.Copy()
 
 	color.Green("Querying backendKite now")
-	backendKites, err := foreignKite.GetKites(protocol.KontrolQuery{
+	backendKites, err := foreignKite.GetKites(&protocol.KontrolQuery{
 		Username:    "testuser",
 		Environment: config.DefaultConfig.Environment,
 		Name:        "backendKite",

--- a/test/kontrolclient_test.go
+++ b/test/kontrolclient_test.go
@@ -49,7 +49,7 @@ func TestRegisterToKontrol(t *testing.T) {
 
 	select {
 	case <-k.KontrolReadyNotify():
-		kites, err := k.GetKites(protocol.KontrolQuery{
+		kites, err := k.GetKites(&protocol.KontrolQuery{
 			Username:    k.Kite().Username,
 			Environment: k.Kite().Environment,
 			Name:        k.Kite().Name,

--- a/watcher.go
+++ b/watcher.go
@@ -61,7 +61,7 @@ func (w *Watcher) rewatch() error {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 
-	id, err := w.localKite.watchKites(*w.query, w.handler)
+	id, err := w.localKite.watchKites(w.query, w.handler)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Some functions/methods were expecting a *KontrolQuery, some of them were
KontrolQuery. All of them are expecting *KontrolQuery now.
