### PR TITLE
kitectl: Always show the keys in the same order.

### DIFF
--- a/kitectl/command/showkey.go
+++ b/kitectl/command/showkey.go
@@ -8,6 +8,16 @@ import (
 	"github.com/mitchellh/cli"
 )
 
+var tokenKeyOrder = []string{
+	"sub",        //  subject
+	"iss",        // issuer
+	"kontrolURL", // kontrol url
+	"aud",        // audience
+	"iat",        // issued at
+	"jti",        // JWT ID
+	"kontrolKey", // kontrol public key
+}
+
 type Showkey struct {
 	Ui cli.Ui
 }
@@ -40,8 +50,8 @@ func (c *Showkey) Run(_ []string) int {
 		return 1
 	}
 
-	for k, v := range token.Claims {
-		c.Ui.Output(fmt.Sprintf("%-15s%+v", k, v))
+	for _, v := range tokenKeyOrder {
+		c.Ui.Output(fmt.Sprintf("%-15s%+v", v, token.Claims[v]))
 	}
 
 	return 0


### PR DESCRIPTION
`kitectl showkey` output was always scrambling the order and it was bugging me.
