### PR TITLE
heartbeat: fix not re-registering when registerHTTP fails

### DIFF
--- a/heartbeat.go
+++ b/heartbeat.go
@@ -183,8 +183,9 @@ func (k *Kite) sendHeartbeats(interval time.Duration, kiteURL *url.URL) {
 		case "pong":
 			return nil
 		case "registeragain":
+			k.Log.Info("Disconnected from Kontrol, going to register again")
 			tick.Stop()
-			k.RegisterHTTP(kiteURL)
+			k.RegisterHTTPForever(kiteURL)
 			return errRegisterAgain
 		}
 

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -148,7 +148,7 @@ func (k *Kite) sendHeartbeats(interval time.Duration, kiteURL *url.URL) {
 
 	heartbeatURL := k.getKontrolPath("heartbeat")
 
-	k.Log.Debug("Sending heartbeat to: %s", heartbeatURL)
+	k.Log.Debug("Starting to send heartbeat to: %s", heartbeatURL)
 
 	u, err := url.Parse(heartbeatURL)
 	if err != nil {
@@ -184,8 +184,11 @@ func (k *Kite) sendHeartbeats(interval time.Duration, kiteURL *url.URL) {
 			return nil
 		case "registeragain":
 			k.Log.Info("Disconnected from Kontrol, going to register again")
-			tick.Stop()
-			k.RegisterHTTPForever(kiteURL)
+			go func() {
+				k.RegisterHTTPForever(kiteURL)
+				tick.Stop()
+			}()
+
 			return errRegisterAgain
 		}
 


### PR DESCRIPTION
Normally registration is forever, until you stop the APP. However if it
fails once to send an heartbeat and Kontrol sends a `registerAgain`, it
would try to re-register it. The problem here is, the registration part
is done once only. So if something goes wrong and the registration
fails, we need to try to register until we are again the loop.

By changing the RegisterHTTP to RegisterHTTPForever, it'll try to
register until it's successfull. Once registered, the heartbeat will be
starting again.