### PR TITLE
Config for KONTROL_STORAGE

### DIFF
--- a/kontrol/kontrol/main.go
+++ b/kontrol/kontrol/main.go
@@ -34,9 +34,9 @@ type Kontrol struct {
 	Postgres struct {
 		Host     string `default:"localhost"`
 		Port     int    `default:"5432"`
-		Username string `required:"true"`
+		Username string
 		Password string
-		DBName   string `required:"true" `
+		DBName   string
 	}
 }
 


### PR DESCRIPTION
The multiconfig require for postgres username/dbname seemingly makes it impossible to utilize the KONTROL_STORAGE env variable for etcd without first setting those