### PR TITLE
method: improve throttle

### DIFF
--- a/method_test.go
+++ b/method_test.go
@@ -13,7 +13,7 @@ func TestMethod_Throttling(t *testing.T) {
 
 	k.HandleFunc("foo", func(r *Request) (interface{}, error) {
 		return "handle", nil
-	}).Throttle(20, time.Second*2)
+	}).Throttle(time.Second*2, 30)
 
 	go k.Run()
 	defer k.Close()


### PR DESCRIPTION
Based on the conversation with @rogpeppe here: https://twitter.com/rogpeppe/status/570224998759079936

Basically previously it was using the Quantum option which would fill the bucket immediately. It would encourage clients to make burst calls. Now there is a consistent flow.