### PR TITLE
add Kite.Port() method

### DIFF
--- a/server.go
+++ b/server.go
@@ -84,6 +84,25 @@ func (k *Kite) listenAndServe() error {
 	return http.Serve(k.listener, k)
 }
 
+// Port returns the TCP port number that the kite listens.
+// Port must be called after the listener is initialized.
+// You can use ServerReadyNotify function to get notified when listener is ready.
+//
+// Kite starts to listen the port when Run() is called.
+// Since Run() is blocking you need to run it as a goroutine the call this function when listener is ready.
+//
+// Example:
+//     k := kite.New("x", "1.0.0")
+//     go k.Run()
+//     <-k.ServerReadyNotify()
+//     port := k.Port()
+func (k *Kite) Port() int {
+	if k.listener == nil {
+		return 0
+	}
+	return k.listener.Addr().(*net.TCPAddr).Port
+}
+
 func (k *Kite) UseTLS(certPEM, keyPEM string) {
 	if k.TLSConfig == nil {
 		k.TLSConfig = &tls.Config{}


### PR DESCRIPTION
Problem:
I have a kite that is configured to listen on random port (0). 
I need to register this kite to Kontrol instance but first I need to know the port number that the kite is listening on.
Currently there is no way of getting the auto-assigned port number.

```go
package main

import (
	"net/url"
	"github.com/koding/kite"
)

func main() {
	k := kite.New("first", "1.0.0")
	k.Config.Port = 0 // auto-assign

	k.Register(&url.URL{Scheme: "http", Host: "127.0.0.1:?????", Path: "/kite"})
	k.Run()
}
```

This PR solves the problem by adding a Port() method to kite that returns the auto-assigned port number.