### PR TITLE
kontrol: provide better result to queries from clients

### DIFF
--- a/kontrol/http.go
+++ b/kontrol/http.go
@@ -155,6 +155,10 @@ func (k *Kontrol) handleRegisterHTTP(rw http.ResponseWriter, req *http.Request) 
 				close(stopped)
 			}
 
+			if err := k.storage.Delete(remoteKite); err != nil {
+				k.log.Error("Could not delete kite '%v' from storage: %s", remoteKite, err)
+			}
+
 			delete(k.heartbeats, remoteKite.ID)
 		})
 	}

--- a/kontrol/kontrol.go
+++ b/kontrol/kontrol.go
@@ -35,7 +35,7 @@ var (
 
 	// HeartbeatDelay is the compensation interval which is added to the
 	// heartbeat to avoid network delays
-	HeartbeatDelay = time.Second * 20
+	HeartbeatDelay = time.Second * 10
 
 	// UpdateInterval is the interval in which the key gets updated
 	// periodically. Keeping it low increase the write load to the storage, so


### PR DESCRIPTION
Two changes:

1. Delay is to much comparing to the heartbeat interval. Missing one
heartbeat means that kontrol waits 30 seconds until it's been marked as
death. A delay which is 2x more than the heartbeat doesn't make sense
to. So lower it to a more realistic value.

2. Once a kite is marked as not reachable, the updater is stopped.
However it's still available in the storage. Only when it hits the TTL
value (which is a very long value of 90 seconds) does it get deleted.
Because of this, we have the following problem:

	1. "mathworker" registers to kontrol at 12:00:00
	2. "mathworkes" crashes or stops at 12:00:10
	3. After 30 seconds (12:00:40) it's been marked and in 90
	   seconds (12:02:10) it'll be deleted from the storage
	4. During the duration 12:00:10 til 12:02:10 any client quering
	   this kite ("mathwork") will get a result from Kontrol.
	   However because mathworker is not running anymore we get the
           error "connection refused".

Ideally on step 4, we should get the error "No kites available", so the
client can be sure that the queried Kite is not running anymore.  That's
why we delete the key immediately once we didn't receive any heartbeat
anymore.

--

So the final result of this PR would be:

Previous: client would get a result from 12:00:00 til 12:02:10 (130
seconds)
Now: client get a result from  12:00:00 til 12:00:30 (30 seconds)

The only disadvantage would be delete(writes) on the storage. However a
service discover should have a more realistic result. So the tradeoff
is worth it.