### PR TITLE
kontrol: make machineAuthenticate more flexible

### DIFF
--- a/kontrol/handlers.go
+++ b/kontrol/handlers.go
@@ -181,12 +181,26 @@ func (k *Kontrol) handleGetToken(r *kite.Request) (interface{}, error) {
 }
 
 func (k *Kontrol) handleMachine(r *kite.Request) (interface{}, error) {
+	var args struct {
+		Username string
+		AuthType string
+	}
+
+	if err := r.Args.One().Unmarshal(&args); err != nil {
+		return nil, err
+	}
+
+	if args.Username == "" {
+		return nil, errors.New("usename is empty")
+	}
+
 	if k.MachineAuthenticate != nil {
-		if err := k.MachineAuthenticate(r); err != nil {
+		// an empty authType is ok, the implementer is responsible of it. It
+		// can care of it or it can return an error
+		if err := k.MachineAuthenticate(args.AuthType, r); err != nil {
 			return nil, errors.New("cannot authenticate user")
 		}
 	}
 
-	username := r.Args.One().MustString() // username should be send as an argument
-	return k.registerUser(username)
+	return k.registerUser(args.Username)
 }

--- a/kontrol/kontrol.go
+++ b/kontrol/kontrol.go
@@ -55,8 +55,10 @@ type Kontrol struct {
 	// MachineAuthenticate is used to authenticate the request in the
 	// "handleMachine" method.  The reason for a separate auth function is, the
 	// request must not be authenticated because clients do not have a kite.key
-	// before they register to this machine.
-	MachineAuthenticate func(r *kite.Request) error
+	// before they register to this machine. Also the requester can send a
+	// authType argument which can be used to distinguish between several
+	// authentication methods
+	MachineAuthenticate func(authType string, r *kite.Request) error
 
 	// RSA keys
 	publicKey  string // for validating tokens


### PR DESCRIPTION
* This allows us to pass additional arguments to authMachine.
* `authType` is a new argument, which the authMachine function can use
  it to decide on how to make the authentication