### PR TITLE
Multi key

### DIFF
--- a/kontrol/001-schema.sql
+++ b/kontrol/001-schema.sql
@@ -11,9 +11,9 @@
 -- drop the user
 -- DROP USER IF EXISTS kontrol;
 
--- drop the table
+-- drop the tables
 -- DROP TABLE IF EXISTS "kite"."kite";
-
+-- DROP TABLE IF EXISTS "kite"."key";
 
 -- create role
 CREATE ROLE kontrol;

--- a/kontrol/002-table.sql
+++ b/kontrol/002-table.sql
@@ -4,6 +4,27 @@ CREATE SCHEMA kite;
 -- give usage access to schema for our role
 GRANT USAGE ON SCHEMA kite TO kontrol;
 
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+--
+-- create key table for storing key pairs
+--
+CREATE TABLE IF NOT EXISTS "kite"."key" (
+    id UUID NOT NULL DEFAULT uuid_generate_v4(),
+    public TEXT NOT NULL COLLATE "default", -- public will store public key of pair
+    private TEXT NOT NULL COLLATE "default", -- private will store private key of pair
+    created_at timestamp(6) WITH TIME ZONE NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC'),
+    deleted_at timestamp(6) WITH TIME ZONE, -- update deleted at if a key pair become obsolote
+
+    -- create constraints along with table creation
+    PRIMARY KEY ("id") NOT DEFERRABLE INITIALLY IMMEDIATE,
+    CONSTRAINT "key_public_unique" UNIQUE ("public") NOT DEFERRABLE INITIALLY IMMEDIATE,
+    CONSTRAINT "key_private_unique" UNIQUE ("private") NOT DEFERRABLE INITIALLY IMMEDIATE,
+    CONSTRAINT "key_created_at_lte_deleted_at_check" CHECK (created_at <= deleted_at)
+) WITH (OIDS = FALSE);
+
+GRANT SELECT, INSERT, UPDATE ON "kite"."key" TO "kontrol"; -- dont allow deletion from this table
+
 -- create the table
 CREATE UNLOGGED TABLE "kite"."kite" (
     username TEXT NOT NULL,
@@ -15,13 +36,17 @@ CREATE UNLOGGED TABLE "kite"."kite" (
     id uuid PRIMARY KEY,
     url TEXT NOT NULL,
     created_at timestamptz NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC'), -- you may set a global timezone
-    updated_at timestamptz NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC')
+    updated_at timestamptz NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC'),
+    key_id UUID NOT NULL,
+
+    CONSTRAINT "kite_key_id_fkey" FOREIGN KEY ("key_id") REFERENCES kite.key (id) ON UPDATE NO ACTION ON DELETE NO ACTION NOT DEFERRABLE INITIALLY IMMEDIATE
 );
 
 -- add proper permissions for table
 GRANT SELECT, INSERT, UPDATE, DELETE ON "kite"."kite" TO "kontrol";
 
--- create the index
+-- create the index, but drop first if exists
 DROP INDEX IF EXISTS kite_updated_at_btree_idx;
 
 CREATE INDEX kite_updated_at_btree_idx ON "kite"."kite" USING BTREE (updated_at DESC);
+

--- a/kontrol/003-migration-001-add-kite-key-table.sql
+++ b/kontrol/003-migration-001-add-kite-key-table.sql
@@ -1,0 +1,40 @@
+--
+-- create key table for storing key pairs
+--
+CREATE TABLE IF NOT EXISTS "kite"."key" (
+    id UUID NOT NULL DEFAULT uuid_generate_v4(),
+    public TEXT NOT NULL COLLATE "default", -- public will store public key of pair
+    private TEXT NOT NULL COLLATE "default", -- private will store private key of pair
+    created_at timestamp(6) WITH TIME ZONE NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC'),
+    deleted_at timestamp(6) WITH TIME ZONE, -- update deleted at if a key pair become obsolote
+
+    -- create constraints along with table creation
+    PRIMARY KEY ("id") NOT DEFERRABLE INITIALLY IMMEDIATE,
+    CONSTRAINT "key_public_unique" UNIQUE ("public") NOT DEFERRABLE INITIALLY IMMEDIATE,
+    CONSTRAINT "key_private_unique" UNIQUE ("private") NOT DEFERRABLE INITIALLY IMMEDIATE,
+    CONSTRAINT "key_created_at_lte_deleted_at_check" CHECK (created_at <= deleted_at)
+) WITH (OIDS = FALSE);
+GRANT SELECT, INSERT, UPDATE ON "kite"."key" TO "kontrol"; -- dont allow deletion from this table
+
+-- add key_id column into kite table
+DO $$
+  BEGIN
+    BEGIN
+      ALTER TABLE kite.kite ADD COLUMN "key_id" UUID NOT NULL;
+    EXCEPTION
+      WHEN duplicate_column THEN RAISE NOTICE 'key_id column already exists';
+    END;
+  END;
+$$;
+
+-- create foreign constraint between kite.kite.key_id and kite.key.id
+DO $$
+  BEGIN
+    BEGIN
+      ALTER TABLE kite.kite ADD CONSTRAINT "kite_key_id_fkey" FOREIGN KEY ("key_id") REFERENCES kite.key (id) ON UPDATE NO ACTION ON DELETE NO ACTION NOT DEFERRABLE INITIALLY IMMEDIATE;
+    EXCEPTION
+      WHEN duplicate_object THEN RAISE NOTICE 'kite_key_id_fkey already exists';
+    END;
+  END;
+$$;
+

--- a/kontrol/handlers.go
+++ b/kontrol/handlers.go
@@ -44,6 +44,12 @@ func (k *Kontrol) handleRegister(r *kite.Request) (interface{}, error) {
 		URL: kiteURL,
 	}
 
+	// just check if the key is valid and is stored in the key pair storage, if
+	// not found we don't allo to register anyone.
+	if _, err := k.keyPair.GetKeyFromPublic(""); err != nil {
+		return nil, err
+	}
+
 	// Register first by adding the value to the storage. Return if there is
 	// any error.
 	if err := k.storage.Upsert(&remote.Kite, value); err != nil {

--- a/kontrol/handlers.go
+++ b/kontrol/handlers.go
@@ -46,7 +46,7 @@ func (k *Kontrol) handleRegister(r *kite.Request) (interface{}, error) {
 	}
 
 	// check if the key is valid and is stored in the key pair storage, if not
-	// found we don't allo to register anyone.
+	// found we don't allow to register anyone.
 	if _, err := k.keyPair.GetKeyFromPublic(publicKey); err != nil {
 		return nil, err
 	}

--- a/kontrol/handlers.go
+++ b/kontrol/handlers.go
@@ -47,7 +47,8 @@ func (k *Kontrol) handleRegister(r *kite.Request) (interface{}, error) {
 
 	// check if the key is valid and is stored in the key pair storage, if not
 	// found we don't allow to register anyone.
-	if _, err := k.keyPair.GetKeyFromPublic(publicKey); err != nil {
+	keyPair, err := k.keyPair.GetKeyFromPublic(publicKey)
+	if err != nil {
 		return nil, err
 	}
 
@@ -59,7 +60,8 @@ func (k *Kontrol) handleRegister(r *kite.Request) (interface{}, error) {
 	}
 
 	value := &kontrolprotocol.RegisterValue{
-		URL: kiteURL,
+		URL:   kiteURL,
+		KeyID: keyPair.ID,
 	}
 
 	// Register first by adding the value to the storage. Return if there is

--- a/kontrol/handlers.go
+++ b/kontrol/handlers.go
@@ -192,9 +192,15 @@ func (k *Kontrol) handleGetToken(r *kite.Request) (interface{}, error) {
 		return nil, errors.New("query matches more than one kite")
 	}
 
+	kite := kites[0]
 	audience := getAudience(query)
 
-	return generateToken(audience, r.Username, k.Kite.Kite().Username, k.privateKey)
+	keyPair, err := k.keyPair.GetKeyFromID(kite.KeyID)
+	if err != nil {
+		return nil, err
+	}
+
+	return generateToken(audience, r.Username, k.Kite.Kite().Username, keyPair.Private)
 }
 
 func (k *Kontrol) handleMachine(r *kite.Request) (interface{}, error) {

--- a/kontrol/keypair.go
+++ b/kontrol/keypair.go
@@ -7,10 +7,10 @@ type KeyPair struct {
 	// ID is the unique id defining the key pair
 	ID string
 
-	// Public key
+	// Public key is used to validate tokens
 	Public string
 
-	// Private key
+	// Private key is used to sign/generate tokens
 	Private string
 }
 

--- a/kontrol/keypair.go
+++ b/kontrol/keypair.go
@@ -1,0 +1,28 @@
+package kontrol
+
+// KeyPair defines a single key pair entity
+type KeyPair struct {
+	// ID is the unique id defining the key pair
+	ID string
+
+	// Public key
+	Public string
+
+	// Private key
+	Private string
+}
+
+// KeyPairStorage is responsible of managing key pairs
+type KeyPairStorage interface {
+	// AddKey adds the given key pair to the storage
+	AddKey(*KeyPair) error
+
+	// DeleteKey deletes the given key pairs from the storage
+	DeleteKey(*KeyPair) error
+
+	// GetKeyFromID retrieves the KeyPair from the given ID
+	GetKeyFromID(id string) (*KeyPair, error)
+
+	// GetKeyFromPublic retrieves the KeyPairs from the given public Key
+	GetKeyFromPublic(publicKey string) (*KeyPair, error)
+}

--- a/kontrol/keypair.go
+++ b/kontrol/keypair.go
@@ -1,5 +1,7 @@
 package kontrol
 
+import "errors"
+
 // KeyPair defines a single key pair entity
 type KeyPair struct {
 	// ID is the unique id defining the key pair
@@ -10,6 +12,21 @@ type KeyPair struct {
 
 	// Private key
 	Private string
+}
+
+func (k *KeyPair) Validate() error {
+	if k.ID == "" {
+		return errors.New("KeyPair ID field is empty")
+	}
+
+	if k.Public == "" {
+		return errors.New("KeyPair Public field is empty")
+	}
+
+	if k.Private == "" {
+		return errors.New("KeyPair Private field is empty")
+	}
+	return nil
 }
 
 // KeyPairStorage is responsible of managing key pairs

--- a/kontrol/kontrol.go
+++ b/kontrol/kontrol.go
@@ -135,6 +135,7 @@ func (k *Kontrol) AddAuthenticator(keyType string, fn func(*kite.Request) error)
 // kontorl.MachineKeyPicker function.
 func (k *Kontrol) AddKeyPair(id, public, private string) error {
 	if k.keyPair == nil {
+		k.log.Warning("Key pair storage is not set. Using in memory cache")
 		k.keyPair = NewMemKeyPairStorage()
 	}
 

--- a/kontrol/kontrol.go
+++ b/kontrol/kontrol.go
@@ -168,7 +168,8 @@ func (k *Kontrol) Run() {
 	}
 
 	if k.keyPair == nil {
-		panic("kontrol key pair storage is not set")
+		k.log.Warning("Key pair storage is not set. Using in memory cache")
+		k.keyPair = NewMemKeyPairStorage()
 	}
 
 	// now go and register ourself

--- a/kontrol/kontrol.go
+++ b/kontrol/kontrol.go
@@ -170,6 +170,8 @@ func (k *Kontrol) registerUser(username string) (kiteKey string, err error) {
 		return "", errors.New("cannot generate a token")
 	}
 
+	panic("pickup a public/private key for registering machines")
+
 	token := jwt.New(jwt.GetSigningMethod("RS256"))
 
 	token.Claims = map[string]interface{}{

--- a/kontrol/kontrol.go
+++ b/kontrol/kontrol.go
@@ -135,7 +135,7 @@ func (k *Kontrol) AddAuthenticator(keyType string, fn func(*kite.Request) error)
 // kontorl.MachineKeyPicker function.
 func (k *Kontrol) AddKeyPair(id, public, private string) error {
 	if k.keyPair == nil {
-		return errors.New("KeyPair storage is not set. Please use kontrol.SetKeyPairStorage() to fix it")
+		k.keyPair = NewMemKeyPairStorage()
 	}
 
 	if id == "" {

--- a/kontrol/kontrol.go
+++ b/kontrol/kontrol.go
@@ -150,6 +150,10 @@ func (k *Kontrol) Run() {
 		panic("kontrol storage is not set")
 	}
 
+	if k.keyPair == nil {
+		panic("kontrol key pair storage is not set")
+	}
+
 	// now go and register ourself
 	go k.registerSelf()
 

--- a/kontrol/kontrol.go
+++ b/kontrol/kontrol.go
@@ -188,6 +188,10 @@ func (k *Kontrol) registerSelf() {
 		value.URL = k.RegisterURL
 	}
 
+	// just add a random uuid key
+	u, _ := uuid.NewV4()
+	value.KeyID = u.String()
+
 	// Register first by adding the value to the storage. We don't return any
 	// error because we need to know why kontrol doesn't register itself
 	if err := k.storage.Add(k.Kite.Kite(), value); err != nil {

--- a/kontrol/kontrol/main.go
+++ b/kontrol/kontrol/main.go
@@ -91,7 +91,9 @@ func main() {
 			DBName:   conf.Postgres.DBName,
 		}
 
-		k.SetStorage(kontrol.NewPostgres(postgresConf, k.Kite.Log))
+		p := kontrol.NewPostgres(postgresConf, k.Kite.Log)
+		k.SetStorage(p)
+		k.SetKeyPairStorage(p)
 	}
 
 	k.Kite.SetLogLevel(kite.DEBUG)

--- a/kontrol/kontrol_test.go
+++ b/kontrol/kontrol_test.go
@@ -421,3 +421,79 @@ func TestGetQueryKey(t *testing.T) {
 		t.Errorf("Key is not expected: %s", key)
 	}
 }
+
+func TestKontrolMultiKey(t *testing.T) {
+	// add so we can use it as key
+	kon.AddKeyPair("", testkeys.PublicSecond, testkeys.PrivateSecond)
+
+	// Start mathworker
+	t.Log("Setting up mathworker")
+	mathKite := kite.New("mathworker", "1.2.3")
+	mathKite.Config = conf.Copy()
+	mathKite.Config.Port = 6161
+	mathKite.HandleFunc("square", Square)
+	go mathKite.Run()
+	<-mathKite.ServerReadyNotify()
+
+	go mathKite.RegisterForever(&url.URL{Scheme: "http", Host: "127.0.0.1:" + strconv.Itoa(mathKite.Config.Port), Path: "/kite"})
+	<-mathKite.KontrolReadyNotify()
+
+	// exp2 kite is the mathworker client. However it uses a different public
+	// key
+	t.Log("Setting up exp2 kite")
+	exp2Kite := kite.New("exp2", "0.0.1")
+	exp2Kite.Config = conf.Copy()
+	exp2Kite.Config.KiteKey = testutil.NewKiteKeyWithKeyPair(testkeys.PrivateSecond, testkeys.PublicSecond).Raw
+	exp2Kite.Config.KontrolKey = testkeys.PrivateSecond
+
+	query := &protocol.KontrolQuery{
+		Username:    exp2Kite.Kite().Username,
+		Environment: exp2Kite.Kite().Environment,
+		Name:        "mathworker",
+		Version:     "~> 1.1",
+	}
+
+	// exp2 queries for mathkite
+	t.Log("Querying for mathworkers")
+	kites, err := exp2Kite.GetKites(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(kites) == 0 {
+		t.Fatal("No mathworker available")
+	}
+
+	// exp2 connectes to mathworker
+	remoteMathWorker := kites[0]
+	err = remoteMathWorker.Dial()
+	if err != nil {
+		t.Fatal("Cannot connect to remote mathworker", err)
+	}
+
+	// Test Kontrol.GetToken
+	t.Logf("oldToken: %s", remoteMathWorker.Auth.Key)
+	newToken, err := exp2Kite.GetToken(&remoteMathWorker.Kite)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("newToken: %s", newToken)
+
+	// Run "square" method
+	response, err := remoteMathWorker.TellWithTimeout("square", 4*time.Second, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var result int
+	err = response.Unmarshal(&result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Result must be "4"
+	if result != 4 {
+		t.Fatalf("Invalid result: %d", result)
+	}
+
+}

--- a/kontrol/kontrol_test.go
+++ b/kontrol/kontrol_test.go
@@ -34,7 +34,7 @@ func init() {
 	conf.ReadEnvironmentVariables()
 
 	DefaultPort = 5555
-	kon = New(conf.Copy(), "0.0.1", testkeys.Public, testkeys.Private)
+	kon = New(conf.Copy(), "0.0.1")
 
 	switch os.Getenv("KONTROL_STORAGE") {
 	case "etcd":
@@ -46,6 +46,8 @@ func init() {
 	default:
 		kon.SetStorage(NewEtcd(nil, kon.Kite.Log))
 	}
+
+	kon.AddKeyPair("", testkeys.Public, testkeys.Private)
 
 	go kon.Run()
 	<-kon.Kite.ServerReadyNotify()

--- a/kontrol/kontrol_test.go
+++ b/kontrol/kontrol_test.go
@@ -56,7 +56,7 @@ func init() {
 }
 
 func TestRegisterMachine(t *testing.T) {
-	key, err := kon.registerUser("foo")
+	key, err := kon.registerUser("foo", testkeys.Public, testkeys.Private)
 	if err != nil {
 		t.Errorf(err.Error())
 		return
@@ -279,7 +279,7 @@ func TestGetToken(t *testing.T) {
 	}
 }
 
-func TestRegister(t *testing.T) {
+func TestRegisterKite(t *testing.T) {
 	t.Log("Setting up mathworker3")
 	kiteURL := &url.URL{Scheme: "http", Host: "localhost:4444", Path: "/kite"}
 	m := kite.New("mathworker3", "1.1.1")

--- a/kontrol/kontrol_test.go
+++ b/kontrol/kontrol_test.go
@@ -40,7 +40,9 @@ func init() {
 	case "etcd":
 		kon.SetStorage(NewEtcd(nil, kon.Kite.Log))
 	case "postgres":
-		kon.SetStorage(NewPostgres(nil, kon.Kite.Log))
+		p := NewPostgres(nil, kon.Kite.Log)
+		kon.SetStorage(p)
+		kon.SetKeyPairStorage(p)
 	default:
 		kon.SetStorage(NewEtcd(nil, kon.Kite.Log))
 	}

--- a/kontrol/kontrol_test.go
+++ b/kontrol/kontrol_test.go
@@ -430,7 +430,7 @@ func TestKontrolMultiKey(t *testing.T) {
 	t.Log("Setting up mathworker")
 	mathKite := kite.New("mathworker", "1.2.3")
 	mathKite.Config = conf.Copy()
-	mathKite.Config.Port = 6161
+	mathKite.Config.Port = 6162
 	mathKite.HandleFunc("square", Square)
 	go mathKite.Run()
 	<-mathKite.ServerReadyNotify()

--- a/kontrol/node.go
+++ b/kontrol/node.go
@@ -52,14 +52,15 @@ func (n *Node) Kite() (*protocol.KiteWithToken, error) {
 		return nil, err
 	}
 
-	url, err := n.Value()
+	val, err := n.Value()
 	if err != nil {
 		return nil, err
 	}
 
 	return &protocol.KiteWithToken{
-		Kite: *kite,
-		URL:  url,
+		Kite:  *kite,
+		URL:   val.URL,
+		KeyID: val.KeyID,
 	}, nil
 }
 
@@ -84,14 +85,10 @@ func (n *Node) KiteFromKey() (*protocol.Kite, error) {
 }
 
 // Value returns the value associated with the current node.
-func (n *Node) Value() (string, error) {
+func (n *Node) Value() (kontrolprotocol.RegisterValue, error) {
 	var rv kontrolprotocol.RegisterValue
 	err := json.Unmarshal([]byte(n.Node.Value), &rv)
-	if err != nil {
-		return "", err
-	}
-
-	return rv.URL, nil
+	return rv, err
 }
 
 // Kites returns a list of kites that are gathered by collecting recursively

--- a/kontrol/postgres.go
+++ b/kontrol/postgres.go
@@ -240,6 +240,10 @@ func (p *Postgres) Upsert(kiteProt *protocol.Kite, value *kontrolprotocol.Regist
 		return err
 	}
 
+	if value.KeyID == "" {
+		return errors.New("postgres: keyId is empty. Aborting upsert")
+	}
+
 	// we are going to try an UPDATE, if it's not successfull we are going to
 	// INSERT the document, all ine one single transaction
 	tx, err := p.DB.Begin()

--- a/kontrol/postgres.go
+++ b/kontrol/postgres.go
@@ -435,16 +435,15 @@ func (p *Postgres) GetKeyFromPublic(public string) (*KeyPair, error) {
 		return nil, err
 	}
 
-	fmt.Printf("sqlQuery = %+v\n", sqlQuery)
-	fmt.Printf("args = %+v\n", args)
-
 	keyPair := &KeyPair{}
 	err = p.DB.QueryRow(sqlQuery, args...).Scan(&keyPair.ID, &keyPair.Public, &keyPair.Private)
 	if err != nil {
 		return nil, err
 	}
 
-	fmt.Printf("keyPair = %+v\n", keyPair)
+	if err := keyPair.Validate(); err != nil {
+		return nil, err
+	}
 
 	return keyPair, nil
 }

--- a/kontrol/postgres.go
+++ b/kontrol/postgres.go
@@ -411,13 +411,8 @@ func (p *Postgres) DeleteKey(keyPair *KeyPair) error {
 		return err
 	}
 
-	n, err := res.RowsAffected()
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("n = %+v\n", n)
-	return nil
+	_, err = res.RowsAffected()
+	return err
 }
 
 func (p *Postgres) GetKeyFromID(id string) (*KeyPair, error) {

--- a/kontrol/postgres.go
+++ b/kontrol/postgres.go
@@ -420,8 +420,10 @@ func (p *Postgres) GetKeyFromID(id string) (*KeyPair, error) {
 	sqlQuery, args, err := psql.
 		Select("id", "public", "private").
 		From("kite.key").
-		Where(map[string]interface{}{"id": id}).
-		ToSql()
+		Where(map[string]interface{}{
+		"id":         id,
+		"deleted_at": nil,
+	}).ToSql()
 	if err != nil {
 		return nil, err
 	}
@@ -440,8 +442,10 @@ func (p *Postgres) GetKeyFromPublic(public string) (*KeyPair, error) {
 	sqlQuery, args, err := psql.
 		Select("id", "public", "private").
 		From("kite.key").
-		Where(map[string]interface{}{"public": public}).
-		ToSql()
+		Where(map[string]interface{}{
+		"public":     public,
+		"deleted_at": nil,
+	}).ToSql()
 	if err != nil {
 		return nil, err
 	}

--- a/kontrol/postgres.go
+++ b/kontrol/postgres.go
@@ -285,19 +285,7 @@ func (p *Postgres) Add(kiteProt *protocol.Kite, value *kontrolprotocol.RegisterV
 		return err
 	}
 
-	// first add our row into the key tabl, otherwise adding a new key to kite
-	// table will fail
-	sqlQuery, args, err := insertKeyQuery(value.KeyID, "2", "2")
-	if err != nil {
-		return err
-	}
-
-	_, err = p.DB.Exec(sqlQuery, args...)
-	if err != nil {
-		return err
-	}
-
-	sqlQuery, args, err = insertKiteQuery(kiteProt, value.URL, value.KeyID)
+	sqlQuery, args, err := insertKiteQuery(kiteProt, value.URL, value.KeyID)
 	if err != nil {
 		return err
 	}
@@ -394,4 +382,34 @@ func insertKeyQuery(id, public, private string) (string, []interface{}, error) {
 		"public",
 		"private",
 	).Values(id, public, private).ToSql()
+}
+
+/*
+
+--- Key Pair -----------------
+
+*/
+
+func (p *Postgres) AddKey(keyPair *KeyPair) error {
+	// first add our row into the key table, otherwise adding a new key to kite
+	// table will fail
+	sqlQuery, args, err := insertKeyQuery(keyPair.ID, keyPair.Public, keyPair.Private)
+	if err != nil {
+		return err
+	}
+
+	_, err = p.DB.Exec(sqlQuery, args...)
+	return err
+}
+
+func (p *Postgres) DeleteKey(keyPair *KeyPair) error {
+	return errors.New("postgres: DeleteKey is not implemented yet")
+}
+
+func (p *Postgres) GetKeyFromID(id string) (*KeyPair, error) {
+	return nil, errors.New("postgres: GetKeyFromID is not implemented yet")
+}
+
+func (p *Postgres) GetKeyFromPublic(public string) (*KeyPair, error) {
+	return nil, errors.New("postgres: GetKeyFromPublic is not implemented yet")
 }

--- a/kontrol/postgres.go
+++ b/kontrol/postgres.go
@@ -406,7 +406,18 @@ func (p *Postgres) AddKey(keyPair *KeyPair) error {
 }
 
 func (p *Postgres) DeleteKey(keyPair *KeyPair) error {
-	return errors.New("postgres: DeleteKey is not implemented yet")
+	res, err := p.DB.Exec(`UPDATE kite.key SET deleted_at = (now() at time zone 'utc')`)
+	if err != nil {
+		return err
+	}
+
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("n = %+v\n", n)
+	return nil
 }
 
 func (p *Postgres) GetKeyFromID(id string) (*KeyPair, error) {

--- a/kontrol/postgres.go
+++ b/kontrol/postgres.go
@@ -406,9 +406,45 @@ func (p *Postgres) DeleteKey(keyPair *KeyPair) error {
 }
 
 func (p *Postgres) GetKeyFromID(id string) (*KeyPair, error) {
-	return nil, errors.New("postgres: GetKeyFromID is not implemented yet")
+	psql := sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
+	sqlQuery, args, err := psql.Select("id", "public", "private").From("kite.key").Where("id", id).ToSql()
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("sqlQuery = %+v\n", sqlQuery)
+	fmt.Printf("args = %+v\n", args)
+
+	keyPair := &KeyPair{}
+	err = p.DB.QueryRow(sqlQuery, args...).Scan(&keyPair.ID, &keyPair.Public)
+	if err != nil {
+		return nil, err
+	}
+
+	return keyPair, nil
 }
 
 func (p *Postgres) GetKeyFromPublic(public string) (*KeyPair, error) {
-	return nil, errors.New("postgres: GetKeyFromPublic is not implemented yet")
+	psql := sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
+	sqlQuery, args, err := psql.
+		Select("id", "public", "private").
+		From("kite.key").
+		Where(map[string]interface{}{"public": public}).
+		ToSql()
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("sqlQuery = %+v\n", sqlQuery)
+	fmt.Printf("args = %+v\n", args)
+
+	keyPair := &KeyPair{}
+	err = p.DB.QueryRow(sqlQuery, args...).Scan(&keyPair.ID, &keyPair.Public, &keyPair.Private)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("keyPair = %+v\n", keyPair)
+
+	return keyPair, nil
 }

--- a/kontrol/postgres.go
+++ b/kontrol/postgres.go
@@ -269,7 +269,7 @@ func (p *Postgres) Upsert(kiteProt *protocol.Kite, value *kontrolprotocol.Regist
 		return nil
 	}
 
-	insertSQL, args, err := insertQuery(kiteProt, value.URL)
+	insertSQL, args, err := insertQuery(kiteProt, value.URL, value.KeyID)
 	if err != nil {
 		return err
 	}
@@ -285,7 +285,7 @@ func (p *Postgres) Add(kiteProt *protocol.Kite, value *kontrolprotocol.RegisterV
 		return err
 	}
 
-	sqlQuery, args, err := insertQuery(kiteProt, value.URL)
+	sqlQuery, args, err := insertQuery(kiteProt, value.URL, value.KeyID)
 	if err != nil {
 		return err
 	}
@@ -347,7 +347,7 @@ func selectQuery(query *protocol.KontrolQuery) (string, []interface{}, error) {
 }
 
 // inseryQuery
-func insertQuery(kiteProt *protocol.Kite, url string) (string, []interface{}, error) {
+func insertQuery(kiteProt *protocol.Kite, url, keyId string) (string, []interface{}, error) {
 	psql := sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 
 	kiteValues := kiteProt.Values()
@@ -358,6 +358,7 @@ func insertQuery(kiteProt *protocol.Kite, url string) (string, []interface{}, er
 	}
 
 	values = append(values, url)
+	values = append(values, keyId)
 
 	return psql.Insert("kite.kite").Columns(
 		"username",
@@ -368,5 +369,6 @@ func insertQuery(kiteProt *protocol.Kite, url string) (string, []interface{}, er
 		"hostname",
 		"id",
 		"url",
+		"key_id",
 	).Values(values...).ToSql()
 }

--- a/kontrol/postgres.go
+++ b/kontrol/postgres.go
@@ -432,10 +432,6 @@ func (p *Postgres) GetKeyFromID(id string) (*KeyPair, error) {
 		return nil, err
 	}
 
-	if err := keyPair.Validate(); err != nil {
-		return nil, err
-	}
-
 	return keyPair, nil
 }
 
@@ -453,10 +449,6 @@ func (p *Postgres) GetKeyFromPublic(public string) (*KeyPair, error) {
 	keyPair := &KeyPair{}
 	err = p.DB.QueryRow(sqlQuery, args...).Scan(&keyPair.ID, &keyPair.Public, &keyPair.Private)
 	if err != nil {
-		return nil, err
-	}
-
-	if err := keyPair.Validate(); err != nil {
 		return nil, err
 	}
 

--- a/kontrol/postgres.go
+++ b/kontrol/postgres.go
@@ -172,6 +172,7 @@ func (p *Postgres) Get(query *protocol.KontrolQuery) (Kites, error) {
 		hostname    string
 		id          string
 		url         string
+		keyId       string
 		updated_at  time.Time
 		created_at  time.Time
 	)
@@ -188,6 +189,7 @@ func (p *Postgres) Get(query *protocol.KontrolQuery) (Kites, error) {
 			&hostname,
 			&id,
 			&url,
+			&keyId,
 			&updated_at,
 			&created_at,
 		)
@@ -205,7 +207,8 @@ func (p *Postgres) Get(query *protocol.KontrolQuery) (Kites, error) {
 				Hostname:    hostname,
 				ID:          id,
 			},
-			URL: url,
+			URL:   url,
+			KeyID: keyId,
 		})
 	}
 

--- a/kontrol/postgres.go
+++ b/kontrol/postgres.go
@@ -172,9 +172,9 @@ func (p *Postgres) Get(query *protocol.KontrolQuery) (Kites, error) {
 		hostname    string
 		id          string
 		url         string
-		keyId       string
 		updated_at  time.Time
 		created_at  time.Time
+		keyId       string
 	)
 
 	kites := make(Kites, 0)
@@ -189,9 +189,9 @@ func (p *Postgres) Get(query *protocol.KontrolQuery) (Kites, error) {
 			&hostname,
 			&id,
 			&url,
-			&keyId,
 			&updated_at,
 			&created_at,
+			&keyId,
 		)
 		if err != nil {
 			return nil, err

--- a/kontrol/protocol/protocol.go
+++ b/kontrol/protocol/protocol.go
@@ -1,6 +1,12 @@
 package protocol
 
-// RegisterValue is the type of the value that is saved to etcd.
+// RegisterValue is the type of the value that is saved to the storage
 type RegisterValue struct {
+	// URL is the Kite's URL that can be accessed
 	URL string `json:"url"`
+
+	// KeyId specifies the public-private key pair reference the kite is using.
+	// This is currently only used by Kontrol itself internally, however it
+	// might be changed in the future.
+	KeyID string `json:"key_id"`
 }

--- a/kontrolclient.go
+++ b/kontrolclient.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
 	"github.com/koding/kite/protocol"
 )
 
@@ -135,12 +134,6 @@ func (k *Kite) getKites(args protocol.GetKitesArgs) ([]*Client, error) {
 
 	clients := make([]*Client, len(result.Kites))
 	for i, currentKite := range result.Kites {
-		_, err := jwt.Parse(currentKite.Token, k.RSAKey)
-		if err != nil {
-			return nil, err
-		}
-
-		// exp := time.Unix(int64(token.Claims["exp"].(float64)), 0).UTC()
 		auth := &Auth{
 			Type: "token",
 			Key:  currentKite.Token,

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -159,6 +159,7 @@ type GetKitesResult struct {
 type KiteWithToken struct {
 	Kite  Kite   `json:"kite"`
 	URL   string `json:"url"`
+	KeyID string `json:"keyId,omitempty"`
 	Token string `json:"token"`
 }
 

--- a/reverseproxy/reverseproxy_test.go
+++ b/reverseproxy/reverseproxy_test.go
@@ -31,16 +31,20 @@ func TestWebSocketProxy(t *testing.T) {
 	// start kontrol
 	color.Green("Starting kontrol")
 	kontrol.DefaultPort = 5555
-	kon := kontrol.New(conf.Copy(), "0.1.0", testkeys.Public, testkeys.Private)
+	kon := kontrol.New(conf.Copy(), "0.1.0")
 
 	switch os.Getenv("KONTROL_STORAGE") {
 	case "etcd":
 		kon.SetStorage(kontrol.NewEtcd(nil, kon.Kite.Log))
 	case "postgres":
-		kon.SetStorage(kontrol.NewPostgres(nil, kon.Kite.Log))
+		p := kontrol.NewPostgres(nil, kon.Kite.Log)
+		kon.SetStorage(p)
+		kon.SetKeyPairStorage(p)
 	default:
 		kon.SetStorage(kontrol.NewEtcd(nil, kon.Kite.Log))
 	}
+
+	kon.AddKeyPair("", testkeys.Public, testkeys.Private)
 
 	go kon.Run()
 	<-kon.Kite.ServerReadyNotify()

--- a/test/kontrolclient_test.go
+++ b/test/kontrolclient_test.go
@@ -29,16 +29,20 @@ func init() {
 	conf.ReadEnvironmentVariables()
 
 	kontrol.DefaultPort = 4099
-	kon := kontrol.New(conf.Copy(), "0.1.0", testkeys.Public, testkeys.Private)
+	kon := kontrol.New(conf.Copy(), "0.1.0")
 
 	switch os.Getenv("KONTROL_STORAGE") {
 	case "etcd":
 		kon.SetStorage(kontrol.NewEtcd(nil, kon.Kite.Log))
 	case "postgres":
-		kon.SetStorage(kontrol.NewPostgres(nil, kon.Kite.Log))
+		p := kontrol.NewPostgres(nil, kon.Kite.Log)
+		kon.SetStorage(p)
+		kon.SetKeyPairStorage(p)
 	default:
 		kon.SetStorage(kontrol.NewEtcd(nil, kon.Kite.Log))
 	}
+
+	kon.AddKeyPair("", testkeys.Public, testkeys.Private)
 
 	go kon.Run()
 	<-kon.Kite.ServerReadyNotify()

--- a/testkeys/testkeys.go
+++ b/testkeys/testkeys.go
@@ -48,6 +48,46 @@ Bt+/AzX98FU9DGJIZTm38OzCFJnbp/awI1QnUqPTtLV3WYtdH58kQUByszdyt7aQ
 RBO19jSxMDjWlQeZbfh/goPdXvuCu8/mgrxa8xO3anx7M5WGrSKS1A==
 -----END RSA PRIVATE KEY-----`
 
+//////////////////////////////////////////////////
+
+const PublicSecond = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyk80fw95zWJ/WZaaYD8C
+l65QC9sHwE1SoJvMgV7nauxWL63aj5MIFgYbrgpG9qr2FBTOvx+tHFkuLzOkykoO
+/blYXqFhsq4ok3euVX0m61tz1IfiEkw+w+fxJDQzzBF0kPrwTlFwND9bx/n89dak
+CtfcyOxiapM5P27oiUzgFNyHuts9+SeuN92Y8zKqk6XKein6emnRU7OeUJALsUTx
+akvGCKwkwDArWYNUF5Vsg7TaIRDgkDZ1frtWI3D34fFyjcEPme7xkXzgsocHM1gL
+4M+YqqToBzg6/PTJRRWXVlK1xfCFl9K9WNG475msjojCxOKOLrFlbaVg4LAO2xT7
+yQIDAQAB
+-----END PUBLIC KEY-----`
+
+const PrivateSecond = `-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEAyk80fw95zWJ/WZaaYD8Cl65QC9sHwE1SoJvMgV7nauxWL63a
+j5MIFgYbrgpG9qr2FBTOvx+tHFkuLzOkykoO/blYXqFhsq4ok3euVX0m61tz1Ifi
+Ekw+w+fxJDQzzBF0kPrwTlFwND9bx/n89dakCtfcyOxiapM5P27oiUzgFNyHuts9
++SeuN92Y8zKqk6XKein6emnRU7OeUJALsUTxakvGCKwkwDArWYNUF5Vsg7TaIRDg
+kDZ1frtWI3D34fFyjcEPme7xkXzgsocHM1gL4M+YqqToBzg6/PTJRRWXVlK1xfCF
+l9K9WNG475msjojCxOKOLrFlbaVg4LAO2xT7yQIDAQABAoIBADapHcryuHsYkMX4
+3e8BN0caLsB1RmvbuGZykdemd6o4/rRVKcc+96FTtyjX2AKPgHs+f/m9qj0Nj1/r
+eSu6xMAi0tCGk+n+CjKF1JF+hgRzKiGTMS62cQLnaQzaGeCaGr+NPV47vLAxKjAm
+yAT4IExZtGqJC7I14vLTmXp3Tdf0nlp3KkQ3Uamm3gZW3OKNQd3+GbdeHOgWbO7W
+eaRilR2uCPkXYdFjho3Q04NzURwrfnlAfKkq1Bb4/vgpoVg35xquHQ7gXXFTr64H
+VG11K6pHDImn5QiiCti7fSYx7lbuuMtPBMvh+5EIefXzib3OASpBrmscpzO2rk9v
+wV3c4e0CgYEA9SOXLp4QxiAUMlMDMOK23K/+ovO8sgiDXdBHsWpQ8RLjnLsR7mVr
+eI/WGTzLtSK4YqWcDquLAyiQids0NmU9g4XLhap1rsf++r231e9bGhzBMP9bYQF1
+YcBB9qK5rujCezZLGKb2Javwv7zvszbjS5usNodBbVPuI9P2dXnaJ/sCgYEA00XV
+WQ4QyvYbft45dlhvwQ3urqP79JGXjQkeFhU3Q95wNGtOuxBV+7TwZRwulB/RNwFV
+eifCmpqQjRX9F4MEag52PmjH63t6GIhvcqkCQ1Qzx8mGs6ydXh6qUs4Xi3t4fk8N
+cjgkAZ69GrRP6GhZN3xyWJFfxarMkCK2yGMIjAsCgYEA0YPKufg04/EU8fILPyP2
+IGZ3XzSsqQknpe3W6KayaWi4iwNEDxo1oYRl+4n/nWAAcaeT2uH43Qk1h+2HEZqz
+2Y5n5WVMUcbzgcDWt41sssOyxrrpkd5aQeK9PhvUUc70MbS0uGwy4v2ytV25DNYz
+rDJwHOa7H8LlPU/zTHKJ5zMCgYEAgo3awsdQVTszznggZiNMG64yWjT3UzBMyFhk
+AR1nI0dnat0Mr8fuejZbfv+lQN9Qd38ZhPzg4oy02ppF5auOpML/Cp3RPJD26AYX
+aHFL9rMntEOyO4FlVW35rmWwYv8PfG35TyWmCmI/VSsrXeBtkT4ToutilVFwS3lI
+HhgkhfUCgYEA741+vMOgrhcpsiSefLMIdOr4Iv6NlfHMbWKvWLDiij2O9P/P/UE+
+vldcz+pdoqFuADPkJaDP2BuSi3qrMtQTtJs8tD3GYwKXRliA0GWiM+PrQ8TU13NA
+CLREiOYwWNgwzHuKvCqCvYoLKP4Ks1eceViCW9v4RyzoMBn9iSiwvzs=
+-----END RSA PRIVATE KEY-----`
+
 ////////////////////////////////////////////////////////////////////////////////
 //
 // TLS certificate

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -17,16 +17,20 @@ import (
 // kontrol.go) If the host does not have a kite.key file kite.New() panics.
 // This is a helper to put a fake key on it's location.
 func NewKiteKey() *jwt.Token {
-	return newKiteKey("")
+	return newKiteKey("", testkeys.Private, testkeys.Public)
 }
 
 // NewKiteKeyUsername is like NewKiteKey() but it uses the given username
 // instead of using the "testuser" name
 func NewKiteKeyUsername(username string) *jwt.Token {
-	return newKiteKey(username)
+	return newKiteKey(username, testkeys.Private, testkeys.Public)
 }
 
-func newKiteKey(username string) *jwt.Token {
+func NewKiteKeyWithKeyPair(private, public string) *jwt.Token {
+	return newKiteKey("", private, public)
+}
+
+func newKiteKey(username, private, public string) *jwt.Token {
 	tknID, err := uuid.NewV4()
 	if err != nil {
 		panic(err)

--- a/tunnelproxy/proxy_test.go
+++ b/tunnelproxy/proxy_test.go
@@ -27,16 +27,20 @@ func TestProxy(t *testing.T) {
 	// start kontrol
 	color.Green("Starting kontrol")
 	kontrol.DefaultPort = 6666
-	kon := kontrol.New(conf.Copy(), "0.1.0", testkeys.Public, testkeys.Private)
+	kon := kontrol.New(conf.Copy(), "0.1.0")
 
 	switch os.Getenv("KONTROL_STORAGE") {
 	case "etcd":
 		kon.SetStorage(kontrol.NewEtcd(nil, kon.Kite.Log))
 	case "postgres":
-		kon.SetStorage(kontrol.NewPostgres(nil, kon.Kite.Log))
+		p := kontrol.NewPostgres(nil, kon.Kite.Log)
+		kon.SetStorage(p)
+		kon.SetKeyPairStorage(p)
 	default:
 		kon.SetStorage(kontrol.NewEtcd(nil, kon.Kite.Log))
 	}
+
+	kon.AddKeyPair("", testkeys.Public, testkeys.Private)
 
 	go kon.Run()
 	<-kon.Kite.ServerReadyNotify()


### PR DESCRIPTION
We have many changes, I'll try my best to summarize:

* Multi key pair backend is added. Why? Because Kontrol was only able to sign and validate Kites based on a single key pair. Now we can use multiple keys to generate tokens and validate incoming requests.
* A new `KeyPairStorage` is being added. This storage interface is responsible of retrieving key pairs and managing them. It has support for Postgres and fallbacks to the in memory if it doesn't exists.
* Machine registrations uses the last set key pair. This can be changed with the `MachineKeyPicker` function if wished.
* Constructor is changed. This is by design, because this whole PR is a fundamental changes and API users need to be aware of it and upgrade. 
* Now key's are added with the `AddKeyPair` method. This can be called  multiple times to add multiple keys.
* External key storage can be added with the `SetKeyPairStorage` method.
* There are no API changes on any Kite interaction related methods. So this means no tests are modified. All changes currently passes the current test suite.