### PR TITLE
Key renew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go: 
+  - 1.3
   - 1.4
-  - tip
 install:
   - go get -d -v -t ./...
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go: 
-  - 1.3
   - 1.4
+  - tip
 install:
   - go get -d -v -t ./...
 script:

--- a/Makefile
+++ b/Makefile
@@ -57,15 +57,15 @@ kontroltest:
 
 
 	@echo "Using as storage: $(KONTROL_STORAGE)"
-	ifeq ($(KONTROL_STORAGE), "etcd")
-		@echo "Killing previous etcd instance"
-		@killall etcd ||:
+ifeq ($(KONTROL_STORAGE), "etcd")
+	@echo "Killing previous etcd instance"
+	@killall etcd ||:
 
-		@echo "Installing etcd"
-		test -d "_etcd" || git clone https://github.com/coreos/etcd _etcd
-		@rm -rf _etcd/kontrol_test ||: #remove previous folder
-		@cd _etcd; ./build; ./bin/etcd --name=kontrol --data-dir=kontrol_test &
-	endif
+	@echo "Installing etcd"
+	test -d "_etcd" || git clone https://github.com/coreos/etcd _etcd
+	@rm -rf _etcd/kontrol_test ||: #remove previous folder
+	@cd _etcd; ./build; ./bin/etcd --name=kontrol --data-dir=kontrol_test &
+endif
 
 	@echo "Creating test key"
 	@`which go` run ./testutil/writekey/main.go
@@ -94,7 +94,7 @@ ifeq ($(KONTROL_STORAGE), etcd)
 
 	@echo "Installing etcd"
 	test -d "_etcd" || git clone https://github.com/coreos/etcd _etcd
-	@rm -rf _etcd/kontrol_test ||: #remove previous folder
+	@rm -rf _etcd/default.etcd ||: #remove previous folder
 	@cd _etcd; ./build; ./bin/etcd &
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,8 @@ ifeq ($(KONTROL_STORAGE), "etcd")
 
 	@echo "Installing etcd"
 	test -d "_etcd" || git clone https://github.com/coreos/etcd _etcd
-	@rm -rf _etcd/kontrol_test ||: #remove previous folder
-	@cd _etcd; ./build; ./bin/etcd --name=kontrol --data-dir=kontrol_test &
+	@rm -rf _etcd/default.etcd ||: #remove previous folder
+	@cd _etcd; ./build; ./bin/etcd &
 endif
 
 	@echo "Creating test key"

--- a/client.go
+++ b/client.go
@@ -407,7 +407,9 @@ func (c *Client) Close() {
 	c.wg.Wait()
 
 	// GC, not to cause a memory leak
+	c.sendMu.Lock()
 	c.send = nil
+	c.sendMu.Unlock()
 }
 
 // sendhub sends the msg received from the send channel to the remote client

--- a/client.go
+++ b/client.go
@@ -47,7 +47,8 @@ type Client struct {
 	Concurrent bool
 
 	// To signal waiters of Go() on disconnect.
-	disconnect chan struct{}
+	disconnect   chan struct{}
+	disconnectMu sync.Mutex // protects disconnect chan
 
 	// To signal about the close
 	closeChan chan struct{}
@@ -273,17 +274,21 @@ func (c *Client) run() {
 	c.callOnDisconnectHandlers()
 
 	// let others know that the client has disconnected
+	c.disconnectMu.Lock()
 	select {
 	case c.disconnect <- struct{}{}:
 	default:
 	}
+	c.disconnectMu.Unlock()
 
 	if c.Reconnect {
 		// we override it so it doesn't get selected next time. Because we are
 		// redialing, so after redial if a new method is called, the disconnect
 		// channel is being read and the local "disconnect" message will be the
 		// final response. This shouldn't be happen for redials.
+		c.disconnectMu.Lock()
 		c.disconnect = make(chan struct{}, 1)
+		c.disconnectMu.Unlock()
 		go c.dialForever(nil)
 	}
 }
@@ -555,6 +560,9 @@ func (c *Client) sendMethod(method string, args []interface{}, timeout time.Dura
 
 	// Waits until the response has came or the connection has disconnected.
 	go func() {
+		c.disconnectMu.Lock()
+		defer c.disconnectMu.Unlock()
+
 		select {
 		case resp := <-doneChan:
 			responseChan <- resp

--- a/kontrol/handlers.go
+++ b/kontrol/handlers.go
@@ -259,8 +259,6 @@ func (k *Kontrol) handleGetKey(r *kite.Request) (interface{}, error) {
 		return publicKey, nil
 	}
 
-	fmt.Printf("err = %+v\n", err)
-
 	keyPair, err := k.pickKey(r)
 	if err != nil {
 		return nil, err

--- a/kontrol/handlers.go
+++ b/kontrol/handlers.go
@@ -288,10 +288,10 @@ func (k *Kontrol) pickKey(r *kite.Request) (*KeyPair, error) {
 		return keyPair, nil
 	}
 
-	if k.lastPublic != "" && k.lastPrivate != "" {
+	if len(k.lastPublic) != 0 && len(k.lastPrivate) != 0 {
 		return &KeyPair{
-			Public:  k.lastPublic,
-			Private: k.lastPrivate,
+			Public:  k.lastPublic[len(k.lastPublic)-1],
+			Private: k.lastPrivate[len(k.lastPrivate)-1],
 		}, nil
 	}
 

--- a/kontrol/handlers.go
+++ b/kontrol/handlers.go
@@ -206,12 +206,6 @@ func (k *Kontrol) handleGetToken(r *kite.Request) (interface{}, error) {
 }
 
 func (k *Kontrol) handleGetKey(r *kite.Request) (interface{}, error) {
-	var query *protocol.KontrolQuery
-	err := r.Args.One().Unmarshal(&query)
-	if err != nil {
-		return nil, errors.New("Invalid query")
-	}
-
 	// Only accept requests with kiteKey because we need this info
 	// for checking if the key is valid and needs to be regenerated
 	if r.Auth.Type != "kiteKey" {
@@ -233,6 +227,8 @@ func (k *Kontrol) handleGetKey(r *kite.Request) (interface{}, error) {
 		// everything is ok, just return the old one
 		return publicKey, nil
 	}
+
+	fmt.Printf("err = %+v\n", err)
 
 	keyPair, err := k.pickKey(r)
 	if err != nil {

--- a/kontrol/keypair.go
+++ b/kontrol/keypair.go
@@ -76,8 +76,16 @@ func (m *MemKeyPairStorage) AddKey(keyPair *KeyPair) error {
 }
 
 func (m *MemKeyPairStorage) DeleteKey(keyPair *KeyPair) error {
+	if keyPair.Public == "" {
+		k, err := m.GetKeyFromID(keyPair.ID)
+		if err != nil {
+			return err
+		}
+
+		m.public.Delete(k.Public)
+	}
+
 	m.id.Delete(keyPair.ID)
-	m.public.Delete(keyPair.Public)
 	return nil
 }
 

--- a/kontrol/keypair.go
+++ b/kontrol/keypair.go
@@ -47,6 +47,10 @@ type KeyPairStorage interface {
 
 	// GetKeyFromPublic retrieves the KeyPairs from the given public Key
 	GetKeyFromPublic(publicKey string) (*KeyPair, error)
+
+	// Is valid checks if the given publicKey is valid or not. It's up to the
+	// implementer how to implement it. A valid public key returns a nil error.
+	IsValid(publicKey string) error
 }
 
 func NewMemKeyPairStorage() *MemKeyPairStorage {
@@ -107,4 +111,9 @@ func (m *MemKeyPairStorage) GetKeyFromPublic(public string) (*KeyPair, error) {
 	}
 
 	return keyPair, nil
+}
+
+func (m *MemKeyPairStorage) IsValid(public string) error {
+	_, err := m.GetKeyFromPublic(public)
+	return err
 }

--- a/kontrol/keypair.go
+++ b/kontrol/keypair.go
@@ -76,10 +76,6 @@ func (m *MemKeyPairStorage) AddKey(keyPair *KeyPair) error {
 }
 
 func (m *MemKeyPairStorage) DeleteKey(keyPair *KeyPair) error {
-	if err := keyPair.Validate(); err != nil {
-		return err
-	}
-
 	m.id.Delete(keyPair.ID)
 	m.public.Delete(keyPair.Public)
 	return nil

--- a/kontrol/kontrol.go
+++ b/kontrol/kontrol.go
@@ -131,8 +131,8 @@ func (k *Kontrol) AddAuthenticator(keyType string, fn func(*kite.Request) error)
 	k.Kite.Authenticators[keyType] = fn
 }
 
-// DeleteKeyPair deletes the key with the given id or public key. (One of each
-// other can be empty)
+// DeleteKeyPair deletes the key with the given id or public key. (One of them
+// can be empty)
 func (k *Kontrol) DeleteKeyPair(id, public string) error {
 	if k.keyPair == nil {
 		return errors.New("Key pair storage is not initialized")

--- a/kontrol/kontrol.go
+++ b/kontrol/kontrol.go
@@ -117,6 +117,7 @@ func New(conf *config.Config, version string) *Kontrol {
 	k.HandleFunc("registerMachine", kontrol.handleMachine).DisableAuthentication()
 	k.HandleFunc("getKites", kontrol.handleGetKites)
 	k.HandleFunc("getToken", kontrol.handleGetToken)
+	k.HandleFunc("getKey", kontrol.handleGetKey)
 
 	k.HandleHTTPFunc("/register", kontrol.handleRegisterHTTP)
 	k.HandleHTTPFunc("/heartbeat", kontrol.handleHeartbeat)

--- a/kontrol/kontrol.go
+++ b/kontrol/kontrol.go
@@ -131,17 +131,27 @@ func (k *Kontrol) AddAuthenticator(keyType string, fn func(*kite.Request) error)
 	k.Kite.Authenticators[keyType] = fn
 }
 
-// DeleteKeyPair deletes the key with the given id or public key. (One of eac
+// DeleteKeyPair deletes the key with the given id or public key. (One of each
 // other can be empty)
 func (k *Kontrol) DeleteKeyPair(id, public string) error {
 	if k.keyPair == nil {
 		return errors.New("Key pair storage is not initialized")
 	}
 
+	pair, err := k.keyPair.GetKeyFromID(id)
+	if err != nil {
+		return err
+	}
+
 	k.keyPair.DeleteKey(&KeyPair{
 		ID:     id,
 		Public: public,
 	})
+
+	// if public is empty
+	if public == "" {
+		public = pair.Public
+	}
 
 	deleteIndex := -1
 	for i, p := range k.lastPublic {

--- a/kontrol/kontrol.go
+++ b/kontrol/kontrol.go
@@ -143,9 +143,21 @@ func (k *Kontrol) DeleteKeyPair(id, public string) error {
 		Public: public,
 	})
 
-	// delete latest added key so it doesn't get picked up
-	k.lastPublic = k.lastPublic[:len(k.lastPublic)-1]
-	k.lastPrivate = k.lastPrivate[:len(k.lastPrivate)-1]
+	deleteIndex := -1
+	for i, p := range k.lastPublic {
+		if p == public {
+			deleteIndex = i
+		}
+	}
+
+	if deleteIndex == -1 {
+		return errors.New("deleteKeyPair: public key not found")
+	}
+
+	// delete the given public key
+	k.lastPublic = append(k.lastPublic[:deleteIndex], k.lastPublic[deleteIndex+1:]...)
+	k.lastPrivate = append(k.lastPrivate[:deleteIndex], k.lastPrivate[deleteIndex+1:]...)
+
 	return nil
 }
 

--- a/kontrol/kontrol/main.go
+++ b/kontrol/kontrol/main.go
@@ -64,7 +64,7 @@ func main() {
 	kiteConf.IP = conf.Ip
 	kiteConf.Port = conf.Port
 
-	k := kontrol.New(kiteConf, conf.Version, string(publicKey), string(privateKey))
+	k := kontrol.New(kiteConf, conf.Version)
 
 	if conf.TLSCertFile != "" || conf.TLSKeyFile != "" {
 		cert, err := tls.LoadX509KeyPair(conf.TLSCertFile, conf.TLSKeyFile)
@@ -94,8 +94,11 @@ func main() {
 		p := kontrol.NewPostgres(postgresConf, k.Kite.Log)
 		k.SetStorage(p)
 		k.SetKeyPairStorage(p)
+	default:
+		k.SetStorage(kontrol.NewEtcd(conf.Machines, k.Kite.Log))
 	}
 
+	k.AddKeyPair("", string(publicKey), string(privateKey))
 	k.Kite.SetLogLevel(kite.DEBUG)
 	k.Run()
 }
@@ -115,7 +118,8 @@ func initialKey(kontrolConf *Kontrol, publicKey, privateKey []byte) {
 
 	conf.KontrolURL = kontrolConf.KontrolURL
 
-	k := kontrol.New(conf, kontrolConf.Version, string(publicKey), string(privateKey))
+	k := kontrol.New(conf, kontrolConf.Version)
+	k.AddKeyPair("", string(publicKey), string(privateKey))
 	err = k.InitializeSelf()
 	if err != nil {
 		log.Fatal(err)

--- a/kontrol/kontrol_test.go
+++ b/kontrol/kontrol_test.go
@@ -513,8 +513,8 @@ func TestKeyRenew(t *testing.T) {
 	go mathKite.RegisterForever(&url.URL{Scheme: "http", Host: "127.0.0.1:" + strconv.Itoa(mathKite.Config.Port), Path: "/kite"})
 	<-mathKite.KontrolReadyNotify()
 
-	fmt.Printf("old = %+v\n", mathKite.Config.KontrolKey)
-	fmt.Printf("new = %+v\n", testkeys.PublicSecond)
+	// fmt.Printf("old = %+v\n", mathKite.Config.KontrolKey)
+	// fmt.Printf("new = %+v\n", testkeys.PublicSecond)
 
 	// now remove the old Key
 
@@ -526,6 +526,6 @@ func TestKeyRenew(t *testing.T) {
 	}
 
 	if publicKey != testkeys.PublicSecond {
-		t.Errorf("Key renewe failed\n\twant:%s\n\tgot :%s\n", testkeys.PublicSecond, publicKey)
+		t.Errorf("Key renew failed\n\twant:%s\n\tgot :%s\n", testkeys.PublicSecond, publicKey)
 	}
 }

--- a/kontrol/kontrol_test.go
+++ b/kontrol/kontrol_test.go
@@ -83,14 +83,12 @@ func TestTokenInvalidation(t *testing.T) {
 	TokenTTL = time.Millisecond * 500
 	TokenLeeway = 0
 
-	t.Log("Setting up mathworker6")
 	testName := "mathworker6"
 	testVersion := "1.1.1"
 	m := kite.New(testName, testVersion)
 	m.Config = conf.Copy()
 	m.Config.Port = 6666
 
-	t.Log("Registering mathworker6")
 	kiteURL := &url.URL{Scheme: "http", Host: "localhost:6666", Path: "/mathworker6"}
 	_, err := m.Register(kiteURL)
 	if err != nil {
@@ -143,7 +141,6 @@ func TestMultiple(t *testing.T) {
 	// number of clients that will query example kites
 	clientNumber := 10
 
-	fmt.Printf("Creating %d example kites\n", kiteNumber)
 	for i := 0; i < kiteNumber; i++ {
 		m := kite.New("example"+strconv.Itoa(i), "0.1."+strconv.Itoa(i))
 		m.Config = conf.Copy()
@@ -156,7 +153,6 @@ func TestMultiple(t *testing.T) {
 		defer m.Close()
 	}
 
-	fmt.Printf("Creating %d clients\n", clientNumber)
 	clients := make([]*kite.Kite, clientNumber)
 	for i := 0; i < clientNumber; i++ {
 		c := kite.New("client"+strconv.Itoa(i), "0.0.1")
@@ -167,7 +163,6 @@ func TestMultiple(t *testing.T) {
 
 	var wg sync.WaitGroup
 
-	fmt.Printf("Querying for example kites with %d conccurent clients randomly\n", clientNumber)
 	timeout := time.After(testDuration)
 
 	// every one second
@@ -201,7 +196,6 @@ func TestMultiple(t *testing.T) {
 				}(i)
 			}
 		case <-timeout:
-			fmt.Println("test stopped")
 			t.SkipNow()
 		}
 
@@ -211,14 +205,11 @@ func TestMultiple(t *testing.T) {
 }
 
 func TestGetKites(t *testing.T) {
-	t.Log("Setting up mathworker4")
-
 	testName := "mathworker4"
 	testVersion := "1.1.1"
 	m := kite.New(testName, testVersion)
 	m.Config = conf.Copy()
 
-	t.Log("Registering ", testName)
 	kiteURL := &url.URL{Scheme: "http", Host: "localhost:4444", Path: "/kite"}
 	_, err := m.Register(kiteURL)
 	if err != nil {
@@ -234,7 +225,6 @@ func TestGetKites(t *testing.T) {
 	}
 
 	// exp2 queries for mathkite
-	t.Log("Querying for mathworker4")
 	exp3 := kite.New("exp3", "0.0.1")
 	exp3.Config = conf.Copy()
 	kites, err := exp3.GetKites(query)
@@ -260,14 +250,12 @@ func TestGetKites(t *testing.T) {
 }
 
 func TestGetToken(t *testing.T) {
-	t.Log("Setting up mathworker5")
 	testName := "mathworker5"
 	testVersion := "1.1.1"
 	m := kite.New(testName, testVersion)
 	m.Config = conf.Copy()
 	m.Config.Port = 6666
 
-	t.Log("Registering mathworker5")
 	kiteURL := &url.URL{Scheme: "http", Host: "localhost:6666", Path: "/kite"}
 	_, err := m.Register(kiteURL)
 	if err != nil {
@@ -282,12 +270,10 @@ func TestGetToken(t *testing.T) {
 }
 
 func TestRegisterKite(t *testing.T) {
-	t.Log("Setting up mathworker3")
 	kiteURL := &url.URL{Scheme: "http", Host: "localhost:4444", Path: "/kite"}
 	m := kite.New("mathworker3", "1.1.1")
 	m.Config = conf.Copy()
 
-	t.Log("Registering mathworker")
 	res, err := m.Register(kiteURL)
 	if err != nil {
 		t.Error(err)
@@ -301,7 +287,6 @@ func TestRegisterKite(t *testing.T) {
 
 func TestKontrol(t *testing.T) {
 	// Start mathworker
-	t.Log("Setting up mathworker")
 	mathKite := kite.New("mathworker", "1.2.3")
 	mathKite.Config = conf.Copy()
 	mathKite.Config.Port = 6161
@@ -313,7 +298,6 @@ func TestKontrol(t *testing.T) {
 	<-mathKite.KontrolReadyNotify()
 
 	// exp2 kite is the mathworker client
-	t.Log("Setting up exp2 kite")
 	exp2Kite := kite.New("exp2", "0.0.1")
 	exp2Kite.Config = conf.Copy()
 
@@ -325,7 +309,6 @@ func TestKontrol(t *testing.T) {
 	}
 
 	// exp2 queries for mathkite
-	t.Log("Querying for mathworkers")
 	kites, err := exp2Kite.GetKites(query)
 	if err != nil {
 		t.Fatal(err)
@@ -343,12 +326,10 @@ func TestKontrol(t *testing.T) {
 	}
 
 	// Test Kontrol.GetToken
-	t.Logf("oldToken: %s", remoteMathWorker.Auth.Key)
-	newToken, err := exp2Kite.GetToken(&remoteMathWorker.Kite)
+	_, err = exp2Kite.GetToken(&remoteMathWorker.Kite)
 	if err != nil {
 		t.Error(err)
 	}
-	t.Logf("newToken: %s", newToken)
 
 	// Run "square" method
 	response, err := remoteMathWorker.TellWithTimeout("square", 4*time.Second, 2)
@@ -430,7 +411,6 @@ func TestKontrolMultiKey(t *testing.T) {
 	}
 
 	// Start mathworker
-	t.Log("Setting up mathworker")
 	mathKite := kite.New("mathworker", "1.2.3")
 	mathKite.Config = conf.Copy()
 	mathKite.Config.Port = 6162
@@ -500,9 +480,7 @@ func TestKontrolMultiKey(t *testing.T) {
 
 	// now invalidate the second key
 	log.Printf("Invalidating %s\n", secondID)
-	if err := kon.keyPair.DeleteKey(&KeyPair{
-		ID: secondID,
-	}); err != nil {
+	if err := kon.DeleteKeyPair(secondID, ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/kontrol/kontrol_test.go
+++ b/kontrol/kontrol_test.go
@@ -429,6 +429,7 @@ func TestKontrolMultiKey(t *testing.T) {
 	exp3Kite.Config.KontrolKey = testkeys.PublicSecond
 
 	query := &protocol.KontrolQuery{
+		Username:    exp3Kite.Kite().Username,
 		Environment: exp3Kite.Kite().Environment,
 		Name:        "mathworker2",
 		Version:     "~> 1.1",

--- a/kontrol/kontrol_test.go
+++ b/kontrol/kontrol_test.go
@@ -326,6 +326,7 @@ func TestKontrol(t *testing.T) {
 	}
 
 	// Test Kontrol.GetToken
+	tokenCache = make(map[string]string) // empty it
 	_, err = exp2Kite.GetToken(&remoteMathWorker.Kite)
 	if err != nil {
 		t.Error(err)
@@ -411,7 +412,7 @@ func TestKontrolMultiKey(t *testing.T) {
 	}
 
 	// Start mathworker
-	mathKite := kite.New("mathworker2", "1.2.3")
+	mathKite := kite.New("mathworker2", "2.0.0")
 	mathKite.Config = conf.Copy()
 	mathKite.Config.Port = 6162
 	mathKite.HandleFunc("square", Square)
@@ -432,7 +433,7 @@ func TestKontrolMultiKey(t *testing.T) {
 		Username:    exp3Kite.Kite().Username,
 		Environment: exp3Kite.Kite().Environment,
 		Name:        "mathworker2",
-		Version:     "~> 1.1",
+		Version:     "2.0.0",
 	}
 
 	// exp3 queries for mathkite
@@ -453,13 +454,12 @@ func TestKontrolMultiKey(t *testing.T) {
 	}
 
 	// Test Kontrol.GetToken
+	tokenCache = make(map[string]string) // empty it
 	newToken, err := exp3Kite.GetToken(&remoteMathWorker.Kite)
 	if err != nil {
 		t.Error(err)
 	}
 
-	fmt.Printf("newToken = %+v\n", newToken)
-	fmt.Printf("remoteMathWorker.Auth.Key = %+v\n", remoteMathWorker.Auth.Key)
 	if remoteMathWorker.Auth.Key == newToken {
 		t.Errorf("Token renew failed. Tokens should be different after renew")
 	}

--- a/kontrol/postgres.go
+++ b/kontrol/postgres.go
@@ -20,6 +20,7 @@ import (
 
 var (
 	ErrQueryFieldsEmpty = errors.New("all query fields are empty")
+	ErrNoKeyFound       = errors.New("no key pair found")
 )
 
 // Postgres holds Postgresql database related configuration
@@ -439,6 +440,9 @@ func (p *Postgres) GetKeyFromID(id string) (*KeyPair, error) {
 	keyPair := &KeyPair{}
 	err = p.DB.QueryRow(sqlQuery, args...).Scan(&keyPair.ID, &keyPair.Public, &keyPair.Private)
 	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrNoKeyFound
+		}
 		return nil, err
 	}
 
@@ -461,6 +465,9 @@ func (p *Postgres) GetKeyFromPublic(public string) (*KeyPair, error) {
 	keyPair := &KeyPair{}
 	err = p.DB.QueryRow(sqlQuery, args...).Scan(&keyPair.ID, &keyPair.Public, &keyPair.Private)
 	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrNoKeyFound
+		}
 		return nil, err
 	}
 

--- a/kontrol/postgres.go
+++ b/kontrol/postgres.go
@@ -428,7 +428,7 @@ func (p *Postgres) IsValid(public string) error {
 	}
 
 	sqlQuery, args, err := psql.
-		Select("*").
+		Select("id").
 		From("kite.key").
 		Where(andQuery).
 		ToSql()
@@ -437,15 +437,15 @@ func (p *Postgres) IsValid(public string) error {
 	}
 
 	fmt.Printf("sqlQuery = %+v\n", sqlQuery)
-	fmt.Printf("args = %+v\n", args)
+	// fmt.Printf("args = %+v\n", args)
 
-	var res bool
-	err = p.DB.QueryRow(sqlQuery, args...).Scan(&res)
+	var id string
+	err = p.DB.QueryRow(sqlQuery, args...).Scan(&id)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("res = %+v\n", res)
+	fmt.Printf("id = %+v\n", id)
 	return nil
 }
 

--- a/kontrol/postgres.go
+++ b/kontrol/postgres.go
@@ -432,9 +432,6 @@ func (p *Postgres) IsValid(public string) error {
 		return err
 	}
 
-	fmt.Printf("sqlQuery = %+v\n", sqlQuery)
-	// fmt.Printf("args = %+v\n", args)
-
 	var id string
 	err = p.DB.QueryRow(sqlQuery, args...).Scan(&id)
 	if err != nil {

--- a/kontrol/postgres.go
+++ b/kontrol/postgres.go
@@ -420,8 +420,7 @@ func (p *Postgres) DeleteKey(keyPair *KeyPair) error {
 	return nil
 }
 
-func (p *Postgres) IsValid(keyPair *KeyPair) error {
-	public := keyPair.Public
+func (p *Postgres) IsValid(public string) error {
 	psql := sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 	andQuery := sq.And{
 		sq.Eq{"public": public},

--- a/kontrol/postgres.go
+++ b/kontrol/postgres.go
@@ -420,6 +420,36 @@ func (p *Postgres) DeleteKey(keyPair *KeyPair) error {
 	return nil
 }
 
+func (p *Postgres) IsValid(keyPair *KeyPair) error {
+	public := keyPair.Public
+	psql := sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
+	andQuery := sq.And{
+		sq.Eq{"public": public},
+		sq.Eq{"deleted_at": nil},
+	}
+
+	sqlQuery, args, err := psql.
+		Select("*").
+		From("kite.key").
+		Where(andQuery).
+		ToSql()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("sqlQuery = %+v\n", sqlQuery)
+	fmt.Printf("args = %+v\n", args)
+
+	var res bool
+	err = p.DB.QueryRow(sqlQuery, args...).Scan(&res)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("res = %+v\n", res)
+	return nil
+}
+
 func (p *Postgres) GetKeyFromID(id string) (*KeyPair, error) {
 	psql := sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 	sqlQuery, args, err := psql.

--- a/kontrolclient.go
+++ b/kontrolclient.go
@@ -202,7 +202,6 @@ func (k *Kite) GetKey() (string, error) {
 	}
 
 	k.Config.KontrolKey = key
-
 	return key, nil
 }
 
@@ -300,6 +299,12 @@ func (k *Kite) Register(kiteURL *url.URL) (*registerResult, error) {
 	parsed, err := url.Parse(rr.URL)
 	if err != nil {
 		k.Log.Error("Cannot parse registered URL: %s", err.Error())
+	}
+
+	// we also received a new public key (means the old one was invalidated).
+	// Use it now.
+	if rr.PublicKey != "" {
+		k.Config.KontrolKey = rr.PublicKey
 	}
 
 	return &registerResult{parsed}, nil

--- a/kontrolclient.go
+++ b/kontrolclient.go
@@ -208,7 +208,7 @@ func (k *Kite) GetKey() (string, error) {
 // NewKeyRenewer renews the internal key every given interval
 func (k *Kite) NewKeyRenewer(interval time.Duration) {
 	ticker := time.NewTicker(interval)
-	for range ticker.C {
+	for _ = range ticker.C {
 		_, err := k.GetKey()
 		if err != nil {
 			k.Log.Warning("Key renew failed: %s", err)

--- a/kontrolclient.go
+++ b/kontrolclient.go
@@ -205,6 +205,17 @@ func (k *Kite) GetKey() (string, error) {
 	return key, nil
 }
 
+// NewKeyRenewer renews the internal key every given interval
+func (k *Kite) NewKeyRenewer(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	for range ticker.C {
+		_, err := k.GetKey()
+		if err != nil {
+			k.Log.Warning("Key renew failed: %s", err)
+		}
+	}
+}
+
 // KontrolReadyNotify returns a channel that is closed when a successful
 // registiration to kontrol is done.
 func (k *Kite) KontrolReadyNotify() chan struct{} {

--- a/kontrolclient.go
+++ b/kontrolclient.go
@@ -179,6 +179,33 @@ func (k *Kite) GetToken(kite *protocol.Kite) (string, error) {
 	return tkn, nil
 }
 
+// GetKey is used to get a new public key from kontrol if the current one is
+// invalidated. The key is also replaced in memory and every request is going
+// to use it. This means even if kite.key contains the old key, the kite itself
+// uses the new one.
+func (k *Kite) GetKey() (string, error) {
+	if err := k.SetupKontrolClient(); err != nil {
+		return "", err
+	}
+
+	<-k.kontrol.readyConnected
+
+	result, err := k.kontrol.TellWithTimeout("getKey", 4*time.Second)
+	if err != nil {
+		return "", err
+	}
+
+	var key string
+	err = result.Unmarshal(&key)
+	if err != nil {
+		return "", err
+	}
+
+	k.Config.KontrolKey = key
+
+	return key, nil
+}
+
 // KontrolReadyNotify returns a channel that is closed when a successful
 // registiration to kontrol is done.
 func (k *Kite) KontrolReadyNotify() chan struct{} {

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -140,6 +140,9 @@ type RegisterResult struct {
 	URL               string `json:"url"`
 	HeartbeatInterval int64  `json:"heartbeatInterval"`
 	Error             string `json:"err,omitempty"`
+	// PublicKey is only available if the public Key of the request is
+	// invalid
+	PublicKey string `json:"publicKey,omitempty"`
 }
 
 type GetKitesArgs struct {

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -58,10 +58,10 @@ func newKiteKey(username, private, public string) *jwt.Token {
 		"iat":        time.Now().UTC().Unix(),      // Issued At
 		"jti":        tknID.String(),               // JWT ID
 		"kontrolURL": "http://localhost:4000/kite", // Kontrol URL
-		"kontrolKey": testkeys.Public,              // Public key of kontrol
+		"kontrolKey": public,                       // Public key of kontrol
 	}
 
-	token.Raw, err = token.SignedString([]byte(testkeys.Private))
+	token.Raw, err = token.SignedString([]byte(private))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This is the second part of multi key based kontrol. It includes an automatic key checker and replacing old keys with new keys, if the old key is expired.

--

* We test for Go `1.4` and `tip` now. `1.3` is removed as we built the binaries already with `1.4` and it's better to look forwards
* Fix many race conditions in the client.go code which was detected with the race detector.
* `register` method now returns a new key if you try to register with an old key. 
* A new `getKey` method is added to Kontrol to retrieve a new public key if the current one is invalidated. 
* Fix internal memory key pair storage, which was failing if public key was empty
* Last set public and private keys is now a list of keys. Because we might invalidate a key, so once invalidated we need use the last set key, for that we we need to store all keys to have a reference to it.
* An external `DeleteKeyPair` method is added which deleted keys
* Kite can now retrieve and update the public key in memory with `GetKey()` (single usage) or the `NewKeyRenewer()` which updates the key every given internal duration.
