### PR TITLE
kontrol: take care of multi keys for HTTP based registration

### DIFF
--- a/heartbeat.go
+++ b/heartbeat.go
@@ -128,6 +128,12 @@ func (k *Kite) RegisterHTTP(kiteURL *url.URL) (*registerResult, error) {
 		return nil, errors.New("heartbeal interval cannot be zero")
 	}
 
+	// we also received a new public key (means the old one was invalidated).
+	// Use it now.
+	if rr.PublicKey != "" {
+		k.Config.KontrolKey = rr.PublicKey
+	}
+
 	parsed, err := url.Parse(rr.URL)
 	if err != nil {
 		k.Log.Error("Cannot parse registered URL: %s", err.Error())

--- a/kontrol/handlers.go
+++ b/kontrol/handlers.go
@@ -3,6 +3,7 @@ package kontrol
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
@@ -50,7 +51,7 @@ func (k *Kontrol) handleRegister(r *kite.Request) (interface{}, error) {
 
 	// check if the key is valid and is stored in the key pair storage, if not
 	// check if there is a new key we can use.
-	keyPair, err = k.keyPair.GetKeyFromPublic(publicKey)
+	keyPair, err = k.keyPair.GetKeyFromPublic(strings.TrimSpace(publicKey))
 	if err != nil {
 		newKey = true
 		keyPair, err = k.pickKey(r)

--- a/kontrol/http.go
+++ b/kontrol/http.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
@@ -103,7 +104,7 @@ func (k *Kontrol) handleRegisterHTTP(rw http.ResponseWriter, req *http.Request) 
 
 	// check if the key is valid and is stored in the key pair storage, if not
 	// found we don't allow to register anyone.
-	keyPair, err = k.keyPair.GetKeyFromPublic(publicKey)
+	keyPair, err = k.keyPair.GetKeyFromPublic(strings.TrimSpace(publicKey))
 	if err != nil {
 		newKey = true
 		keyPair, err = k.pickKey(&kite.Request{

--- a/kontrol/kontrol.go
+++ b/kontrol/kontrol.go
@@ -190,6 +190,9 @@ func (k *Kontrol) AddKeyPair(id, public, private string) error {
 		id = i.String()
 	}
 
+	public = strings.TrimSpace(public)
+	private = strings.TrimSpace(private)
+
 	keyPair := &KeyPair{
 		ID:      id,
 		Public:  public,


### PR DESCRIPTION
Two changes in this PR:

1. We now trim any whitespace when adding or retrieving keys. Otherwise it's get difficult to retrieve as a single whitespace might cause the key to be not found
2. HTTP based registration was broken, fixed and synced it with XHR and WebSocket based one.