### PR TITLE
Added backoff to RegisterHTTPForever

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,9 +1,38 @@
 package utils
 
 import (
+	"math"
+	"math/rand"
 	"net"
 	"strconv"
+	"time"
 )
+
+func init() {
+	rand.Seed(time.Now().Unix())
+}
+
+// Backoff implements a basic Backoff based on the number of attempts,
+// the duration of time that you want to add on each attempt, and the
+// maximum backoff duration.
+//
+// Note that the maxBackoff is a max for the multiplier only. The
+// final result can be `maxBackoff / 2 + rand(maxBackoff)` big. In
+// other words if the maxBackoff is 60s, then the Backoff returned can
+// be anywhere from 30s, to 1m30s.
+func Backoff(attempts int, delay, maxBackoff time.Duration) time.Duration {
+	fDelay := float64(delay)
+	fMaxBackoff := float64(maxBackoff)
+
+	backoff := fDelay * math.Pow(1.6, float64(attempts))
+
+	if backoff > fMaxBackoff {
+		backoff = fMaxBackoff
+	}
+
+	// Randomize the result
+	return time.Duration(backoff/2 + rand.Float64()*backoff)
+}
 
 // RandomPort() returns a random port to be used with net.Listen(). It's an
 // helper function to register to kontrol before binding to a port. Note that


### PR DESCRIPTION
- A Backoff utility method has been added, that simply accepts the number of attempts, the desired delay between each attempt, and the maximum backoff to increment to. The returned value is randomized as well.
- The newly added Backoff utility method is being used in RegisterHTTPForever.