### PR TITLE
backoff: Added backoff to Kite.RegisterHTTPForever()

### DIFF
--- a/heartbeat.go
+++ b/heartbeat.go
@@ -74,7 +74,10 @@ func (k *Kite) RegisterHTTPForever(kiteURL *url.URL) {
 	}
 
 	// this will retry register forever
-	backoff.Retry(register, k.httpRegisterBackOff)
+	err := backoff.Retry(register, k.httpRegisterBackOff)
+	if err != nil {
+		k.Log.Error("BackOff stopped retrying with Error '%s'", err)
+	}
 }
 
 func (k *Kite) getKontrolPath(path string) string {

--- a/kite.go
+++ b/kite.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cenkalti/backoff"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/mux"
 	"github.com/koding/kite/config"
@@ -75,9 +74,6 @@ type Kite struct {
 	// from kontrol
 	kontrol *kontrolClient
 
-	// Time to wait before repeated RegisterHTTPForever attempts.
-	httpRegisterBackOff *backoff.ExponentialBackOff
-
 	// Handlers to call when a new connection is received.
 	onConnectHandlers []func(*Client)
 
@@ -124,30 +120,22 @@ func New(name, version string) *Kite {
 		registerChan:    make(chan *url.URL, 1),
 	}
 
-	// Create the httpBackoffRegister that RegisterHTTPForever will
-	// use to backoff repeated register attempts.
-	httpRegisterBackOff := backoff.NewExponentialBackOff()
-	httpRegisterBackOff.InitialInterval = 10 * time.Second
-	httpRegisterBackOff.Multiplier = 1.7
-	httpRegisterBackOff.MaxElapsedTime = 0
-
 	k := &Kite{
-		Config:              config.New(),
-		Log:                 l,
-		SetLogLevel:         setlevel,
-		Authenticators:      make(map[string]func(*Request) error),
-		trustedKontrolKeys:  make(map[string]string),
-		handlers:            make(map[string]*Method),
-		preHandlers:         make([]Handler, 0),
-		postHandlers:        make([]Handler, 0),
-		kontrol:             kClient,
-		httpRegisterBackOff: httpRegisterBackOff,
-		name:                name,
-		version:             version,
-		Id:                  kiteID.String(),
-		readyC:              make(chan bool),
-		closeC:              make(chan bool),
-		muxer:               mux.NewRouter(),
+		Config:             config.New(),
+		Log:                l,
+		SetLogLevel:        setlevel,
+		Authenticators:     make(map[string]func(*Request) error),
+		trustedKontrolKeys: make(map[string]string),
+		handlers:           make(map[string]*Method),
+		preHandlers:        make([]Handler, 0),
+		postHandlers:       make([]Handler, 0),
+		kontrol:            kClient,
+		name:               name,
+		version:            version,
+		Id:                 kiteID.String(),
+		readyC:             make(chan bool),
+		closeC:             make(chan bool),
+		muxer:              mux.NewRouter(),
 	}
 
 	// We change the heartbeat interval from 25 seconds to 10 seconds. This is


### PR DESCRIPTION
The existing Backoff library is being used to backoff repeated attempts
to from RegisterHTTPForever(). The backoff numbers have been tweaked to
be generous, as discussed with Cihangir.