### PR TITLE
postgres: Added postgres timeout to kontrol

### DIFF
--- a/kontrol/kontrol/main.go
+++ b/kontrol/kontrol/main.go
@@ -32,11 +32,12 @@ type Kontrol struct {
 	Version  string `default:"0.0.1"`
 
 	Postgres struct {
-		Host     string `default:"localhost"`
-		Port     int    `default:"5432"`
-		Username string
-		Password string
-		DBName   string
+		Host           string `default:"localhost"`
+		Port           int    `default:"5432"`
+		Username       string
+		Password       string
+		DBName         string
+		ConnectTimeout int `default:"20"`
 	}
 }
 

--- a/kontrol/postgres.go
+++ b/kontrol/postgres.go
@@ -25,11 +25,12 @@ var (
 
 // Postgres holds Postgresql database related configuration
 type PostgresConfig struct {
-	Host     string `default:"localhost"`
-	Port     int    `default:"5432"`
-	Username string `required:"true"`
-	Password string
-	DBName   string `required:"true" `
+	Host           string `default:"localhost"`
+	Port           int    `default:"5432"`
+	Username       string `required:"true"`
+	Password       string
+	DBName         string `required:"true" `
+	ConnectTimeout int    `default:"20"`
 }
 
 type Postgres struct {
@@ -61,8 +62,8 @@ func NewPostgres(conf *PostgresConfig, log kite.Logger) *Postgres {
 	}
 
 	connString := fmt.Sprintf(
-		"host=%s port=%d dbname=%s user=%s password=%s sslmode=disable",
-		conf.Host, conf.Port, conf.DBName, conf.Username, conf.Password,
+		"host=%s port=%d dbname=%s user=%s password=%s sslmode=disable connect_timeout=%d",
+		conf.Host, conf.Port, conf.DBName, conf.Username, conf.Password, conf.ConnectTimeout,
 	)
 
 	db, err := sql.Open("postgres", connString)


### PR DESCRIPTION
Added an option to kontrol to specify the postgres `connect_timeout` option, defaulting to 20 seconds.

cc @cihangir @fatih 