### PR TITLE
backoff: Increased backoff to a maximum of 5m, with an Initial of 30s

### DIFF
--- a/heartbeat.go
+++ b/heartbeat.go
@@ -64,7 +64,8 @@ func (k *Kite) RegisterHTTPForever(kiteURL *url.URL) {
 	// Create the httpBackoffRegister that RegisterHTTPForever will
 	// use to backoff repeated register attempts.
 	httpRegisterBackOff := backoff.NewExponentialBackOff()
-	httpRegisterBackOff.InitialInterval = 10 * time.Second
+	httpRegisterBackOff.InitialInterval = 30 * time.Second
+	httpRegisterBackOff.MaxInterval = 5 * time.Minute
 	httpRegisterBackOff.Multiplier = 1.7
 	httpRegisterBackOff.MaxElapsedTime = 0
 


### PR DESCRIPTION
The backoff and variance was proving to be too small with any sizable amount of load, so this PR increases the backoff time, and allows the variance to be more meaningfully random given the larger max backoff.

cc @fatih 