### PR TITLE
kontrol: re-add when update fails

### DIFF
--- a/kontrol/etcd.go
+++ b/kontrol/etcd.go
@@ -108,7 +108,11 @@ func (e *Etcd) Update(k *protocol.Kite, value *kontrolprotocol.RegisterValue) er
 	// Example "/koding/production/os/0.0.1/sj/kontainer1.sj.koding.com/1234asdf..."
 	_, err = e.client.Update(etcdKey, valueString, uint64(KeyTTL/time.Second))
 	if err != nil {
-		return err
+		err = e.Add(k, value)
+		if err != nil {
+			return err
+		}
+		return nil
 	}
 
 	// Also update the the kite.Key Id for easy lookup


### PR DESCRIPTION
when the ttl expires, update will no longer work due to etcd returning a key not found error. try to add the kite again, which gets things working again. without this, kite keeps retrying and failing forever, and the service needs to be restarted for it to work.