### PR TITLE
kite: Added ClientFunc on Kite struct

### DIFF
--- a/client.go
+++ b/client.go
@@ -133,6 +133,7 @@ type response struct {
 func (k *Kite) NewClient(remoteURL string) *Client {
 	c := &Client{
 		LocalKite:     k,
+		ClientFunc:    k.ClientFunc,
 		URL:           remoteURL,
 		disconnect:    make(chan struct{}, 1),
 		closeChan:     make(chan struct{}),

--- a/kite.go
+++ b/kite.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/koding/kite/config"
 	"github.com/koding/kite/protocol"
+	"github.com/koding/kite/sockjsclient"
 	uuid "github.com/satori/go.uuid"
 	"gopkg.in/igm/sockjs-go.v2/sockjs"
 )
@@ -52,6 +53,12 @@ type Kite struct {
 	// Contains different functions for authenticating user from request.
 	// Keys are the authentication types (options.auth.type).
 	Authenticators map[string]func(*Request) error
+
+	// ClientFunc is used as the default value for kite.Client.ClientFunc.
+	// If nil, a default ClientFunc will be used.
+	//
+	// See also: kite.Client.ClientFunc docstring.
+	ClientFunc func(*sockjsclient.DialOptions) *http.Client
 
 	// Kontrol keys to trust. Kontrol will issue access tokens for kites
 	// that are signed with the private counterpart of these keys.


### PR DESCRIPTION
Due to `Kite.kontrol.Client` not being exposed _(or existing before
being dialed)_, api users were unable to set the `Client.ClientFunc`
field for the Kontrol Client.

This commit simply adds a ClientFunc field onto the Kite itself, which
will also be used as the default ClientFunc value for any Client's created from
the Kite - including `Kite.kontrol.Client`.

cc @rjeczalik @cihangir 