### PR TITLE
TMS-2624 tokenrenewer: add 2 defensive checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ kontrol:
 	@`which go` run kontrol/kontrol/main.go -publickeyfile /tmp/publicKey.pem -privatekeyfile /tmp/privateKey.pem -initial -username kite -kontrolurl "http://localhost:4444/kite"
 
 	@echo "$(OK_COLOR)==> Running Kontrol $(NO_COLOR)"
-	@`which go` run kontrol/kontrol/main.go -publickeyfile /tmp/publicKey.pem -privatekeyfile /tmp/privateKey.pem -port 4444 
+	@`which go` run kontrol/kontrol/main.go -publickeyfile /tmp/publicKey.pem -privatekeyfile /tmp/privateKey.pem -port 4444
 
 install:
 	@echo "$(OK_COLOR)==> Downloading dependencies$(NO_COLOR)"
@@ -62,7 +62,7 @@ ifeq ($(KONTROL_STORAGE), "etcd")
 	@killall etcd ||:
 
 	@echo "Installing etcd"
-	test -d "_etcd" || git clone https://github.com/coreos/etcd _etcd
+	test -d "_etcd" || git clone -b release-2.3 https://github.com/coreos/etcd _etcd
 	@rm -rf _etcd/default.etcd ||: #remove previous folder
 	@cd _etcd; ./build; ./bin/etcd &
 endif
@@ -76,7 +76,7 @@ endif
 	@echo "$(OK_COLOR)==> Starting kontrol test $(NO_COLOR)"
 	@`which go` test -race $(VERBOSE) ./kontrol
 
-test: 
+test:
 	@echo "$(OK_COLOR)==> Preparing test environment $(NO_COLOR)"
 	@echo "Using $(KITE_TRANSPORT) transport"
 	@echo "Cleaning $(KITE_HOME) directory"
@@ -93,7 +93,7 @@ ifeq ($(KONTROL_STORAGE), etcd)
 	@killall etcd ||:
 
 	@echo "Installing etcd"
-	test -d "_etcd" || git clone https://github.com/coreos/etcd _etcd
+	test -d "_etcd" || git clone -b release-2.3 https://github.com/coreos/etcd _etcd
 	@rm -rf _etcd/default.etcd ||: #remove previous folder
 	@cd _etcd; ./build; ./bin/etcd &
 endif

--- a/kontrolclient.go
+++ b/kontrolclient.go
@@ -78,12 +78,14 @@ func (k *Kite) SetupKontrolClient() error {
 		k.Log.Info("Connected to Kontrol ")
 
 		// try to re-register on connect
+		k.kontrol.Lock()
 		if k.kontrol.lastRegisteredURL != nil {
 			select {
 			case k.kontrol.registerChan <- k.kontrol.lastRegisteredURL:
 			default:
 			}
 		}
+		k.kontrol.Unlock()
 
 		// signal all other methods that are listening on this channel, that we
 		// are connected to kontrol.
@@ -244,7 +246,9 @@ func (k *Kite) RegisterForever(kiteURL *url.URL) error {
 		for u := range k.kontrol.registerChan {
 			_, err := k.Register(u)
 			if err == nil {
+				k.kontrol.Lock()
 				k.kontrol.lastRegisteredURL = u
+				k.kontrol.Unlock()
 				k.signalReady()
 				continue
 			}


### PR DESCRIPTION
`tokenrenewer` was reported to panic while handling disconnect signal
with the following stacktrace:

  panic: close of closed channel

  goroutine 282305 [running]:
  github.com/koding/kite.func·034()
    github.com/koding/kite/tokenrenewer.go:64 +0x2e
  github.com/koding/kite.func·006()
    github.com/koding/kite/client.go:498 +0x4f
  github.com/koding/kite.(*Client).callOnDisconnectHandlers(0xc20aaf9a40)
    github.com/koding/kite/client.go:499 +0xdc
  github.com/koding/kite.(*Client).run(0xc20aaf9a40)
    github.com/koding/kite/client.go:290 +0x13a
  created by github.com/koding/kite.(*Client).dialForever
    github.com/koding/kite/client.go:255 +0xc1

This PR:

- ensures the handlers are registered only once as multiple disconnect handlers
  would start renew loop multiple times
- signals disconnection events by sending values instead of closing /
  recreating the t.disconnect channel
