### PR TITLE
dnode: rework scrubbing to make it work on go1.6+  - fixes #149

### DIFF
--- a/dnode/partial_test.go
+++ b/dnode/partial_test.go
@@ -1,9 +1,6 @@
 package dnode
 
-import (
-	"fmt"
-	"testing"
-)
+import "testing"
 
 func TestUnmarshalArguments(t *testing.T) {
 	arguments := &Partial{Raw: []byte(`["hello", "world"]`)}
@@ -11,8 +8,6 @@ func TestUnmarshalArguments(t *testing.T) {
 	var s []string
 
 	arguments.MustUnmarshal(&s)
-
-	fmt.Printf("s: %#v\n", s)
 
 	if len(s) != 2 {
 		t.Errorf("Invalid array length: %d", len(s))

--- a/dnode/scrub.go
+++ b/dnode/scrub.go
@@ -7,155 +7,137 @@ import (
 	"sync/atomic"
 )
 
+// Scrub creates an object that represents "callbacks" field in dnode message.
+// The obj argument which will be scrubbed must be of array, slice, struct, or
+// map type. If structure is passed, the returned callbacks map will contain its
+// exported methods of func(*Partial) signature. Other functions must be
+// wrapped by Callback function.
 func (s *Scrubber) Scrub(obj interface{}) (callbacks map[string]Path) {
 	callbacks = make(map[string]Path)
-	s.collectCallbacks(obj, make(Path, 0), callbacks)
+	rv := reflect.ValueOf(obj)
+
+	k := rv.Kind()
+	if k != reflect.Array && k != reflect.Slice && k != reflect.Struct && k != reflect.Map {
+		return nil
+	}
+
+	s.collect(rv, make(Path, 0), callbacks)
 	return callbacks
 }
 
-// collectCallbacks walks over the rawObj and populates callbackMap
-// with callbacks. This is a recursive function. The top level send must
-// sends arguments as rawObj, an empty path and empty callbackMap parameter.
-func (s *Scrubber) collectCallbacks(rawObj interface{}, path Path, callbackMap map[string]Path) {
-	// fmt.Printf("--- collectCallbacks: %#v\n", rawObj)
+var dnodeFunctionType = reflect.TypeOf(new(Function)).Elem()
 
-	// TODO Use reflection and remove this outer switch statement.
-	switch obj := rawObj.(type) {
-	// skip nil values
-	case nil:
-	case []interface{}:
-		for i, item := range obj {
-			s.collectCallbacks(item, append(path, i), callbackMap)
+func (s *Scrubber) collect(rv reflect.Value, path Path, callbacks map[string]Path) {
+	switch rv.Kind() {
+	case reflect.Interface:
+		if !rv.IsNil() {
+			s.collect(rv.Elem(), path, callbacks)
 		}
-	case map[string]interface{}:
-		for key, item := range obj {
-			s.collectCallbacks(item, append(path, key), callbackMap)
+	case reflect.Ptr:
+		if rv.IsNil() {
+			return
 		}
-	// Dereference and continue.
-	case *[]interface{}:
-		if obj != nil {
-			s.collectCallbacks(*obj, path, callbackMap)
+		// collect from structs that define pointer reciver methods.
+		if elem := rv.Elem(); elem.Kind() == reflect.Struct {
+			s.fields(elem, path, callbacks)
+			s.methods(rv, path, callbacks)
+		} else {
+			s.collect(elem, path, callbacks)
 		}
-	// Dereference and continue.
-	case *map[string]interface{}:
-		if obj != nil {
-			s.collectCallbacks(*obj, path, callbackMap)
+	case reflect.Array, reflect.Slice:
+		for i, v := 0, rv.Len(); i < v; i++ {
+			s.collect(rv.Index(i), append(path, i), callbacks)
 		}
-	default:
-		v := reflect.ValueOf(obj)
-
-		switch v.Kind() {
-		case reflect.Func:
-			panic("cannot marshal func, use Callback() to wrap it")
-			// s.registerCallback(v, path, callbackMap)
-		case reflect.Ptr:
-			e := v.Elem()
-			if e == reflect.ValueOf(nil) {
-				return
+	case reflect.Map:
+		for _, mrv := range rv.MapKeys() {
+			s.collect(rv.MapIndex(mrv), append(path, mrv.String()), callbacks)
+		}
+	case reflect.Struct:
+		// register callback functions wrapper.
+		if rv.Type() == dnodeFunctionType {
+			if cb := rv.Interface().(Function); cb.Caller != nil {
+				s.register(cb.Caller.(callback), path, callbacks)
 			}
-
-			v2 := reflect.ValueOf(e.Interface())
-			if v2.Type() == reflect.TypeOf(Function{}) {
-				s.registerCallback(v2, path, callbackMap)
-				return
-			}
-
-			s.collectFields(v2, path, callbackMap)
-			s.collectMethods(v, path, callbackMap)
-		case reflect.Struct:
-			if v.Type() == reflect.TypeOf(Function{}) {
-				s.registerCallback(v, path, callbackMap)
-				return
-			}
-
-			s.collectFields(v, path, callbackMap)
-			s.collectMethods(v, path, callbackMap)
+			return
 		}
+		s.fields(rv, path, callbacks)
+		s.methods(rv, path, callbacks)
+	case reflect.Func:
+		panic("cannot marshal func, use Callback() to wrap it")
 	}
 }
 
-// collectFields collects callbacks from the exported fields of a struct.
-func (s *Scrubber) collectFields(v reflect.Value, path Path, callbackMap map[string]Path) {
-	for i := 0; i < v.NumField(); i++ {
-		f := v.Type().Field(i)
-
-		if f.PkgPath != "" { // unexported
+// fields walks over a structure and scrubs its fields.
+func (s *Scrubber) fields(rv reflect.Value, path Path, callbacks map[string]Path) {
+	for i := 0; i < rv.NumField(); i++ {
+		sf := rv.Type().Field(i)
+		if sf.PkgPath != "" && !sf.Anonymous { // unexported.
 			continue
 		}
 
-		// Do not collect callbacks for "-" tagged fields.
-		tag := f.Tag.Get("dnode")
-		if tag == "-" { // "-" means do not collect callbacks of this field
-			continue
+		// dnode uses JSON package tags for field naming so we need to
+		// discard their comma-separated options.
+		tag := sf.Tag.Get("json")
+		if idx := strings.Index(tag, ","); idx != -1 {
+			tag = tag[:idx]
 		}
-
-		tag = f.Tag.Get("json")
 		if tag == "-" {
 			continue
 		}
-
-		var name string
-		if tag != "" {
-			name = tag
-		} else {
-			name = f.Name
+		// do not collect callbacks for "-" tagged fields.
+		if skip := sf.Tag.Get("dnode"); skip == "-" {
+			continue
 		}
 
-		if f.Anonymous {
-			s.collectCallbacks(v.Field(i).Interface(), path, callbackMap)
+		var name = tag
+		if name == "" {
+			name = sf.Name
+		}
+
+		if sf.Anonymous {
+			s.collect(rv.Field(i), path, callbacks)
 		} else {
-			s.collectCallbacks(v.Field(i).Interface(), append(path, name), callbackMap)
+			s.collect(rv.Field(i), append(path, name), callbacks)
 		}
 	}
 }
 
-func (s *Scrubber) collectMethods(v reflect.Value, path Path, callbackMap map[string]Path) {
-	for i := 0; i < v.NumMethod(); i++ {
-		if v.Type().Method(i).PkgPath == "" { // exported
-			name := v.Type().Method(i).Name
+// methods walks over a structure and scrubs its exported methods.
+func (s *Scrubber) methods(rv reflect.Value, path Path, callbacks map[string]Path) {
+	for i := 0; i < rv.NumMethod(); i++ {
+		if rv.Type().Method(i).PkgPath == "" { // exported
+			cb, ok := rv.Method(i).Interface().(func(*Partial))
+			if !ok {
+				continue
+			}
+
+			name := rv.Type().Method(i).Name
 			name = strings.ToLower(name[0:1]) + name[1:]
-			s.registerCallback(v.Method(i), append(path, name), callbackMap)
+			s.register(cb, append(path, name), callbacks)
 		}
 	}
 }
 
-// registerCallback is called when a function/method is found in arguments array.
-func (s *Scrubber) registerCallback(val reflect.Value, path Path, callbackMap map[string]Path) {
-	if len(path) == 0 {
-		panic("root element must be a struct or slice")
-	}
-
-	var cb func(*Partial) // We are going to save this in scubber
-
-	// Save in client callbacks so we can call it when we receive a call.
-	switch f := val.Interface().(type) {
-	case Function:
-		if f.Caller == nil {
-			return
-		}
-		cb = f.Caller.(callback)
-	case func(*Partial):
-		cb = f
-	default:
-		// TODO enable panic in registerCallback ans see what happens.
-		// panic(fmt.Sprintf("invalid callback: %#v", i))
+// register is called when a function/method is found in arguments array. It
+// assigns an unique ID to the passed callback and stores it internally.
+func (s *Scrubber) register(cb func(*Partial), path Path, callbacks map[string]Path) {
+	// do not register nil callbacks.
+	if cb == nil {
 		return
 	}
-
-	// Subtract one to start counting from zero.
-	// This is not absolutely necessary, just cosmetics.
+	// subtract one to start counting from zero. This is not absolutely
+	// necessary, just cosmetics.
 	next := atomic.AddUint64(&s.seq, 1) - 1
-
 	seq := strconv.FormatUint(next, 10)
 
-	// Save in scubber callbacks
+	// save in scubber callbacks.
 	s.Lock()
 	s.callbacks[next] = cb
 	s.Unlock()
 
-	// Add to callback map to be sent to remote.
-	// Make a copy of path because it is reused in caller.
+	// Add to callback map to be sent to remote. Make a copy of path because it
+	// is reused in caller.
 	pathCopy := make(Path, len(path))
 	copy(pathCopy, path)
-	callbackMap[seq] = pathCopy
+	callbacks[seq] = pathCopy
 }

--- a/dnode/scrub_test.go
+++ b/dnode/scrub_test.go
@@ -18,15 +18,18 @@ func TestScrub(t *testing.T) {
 		{"foo", nil},
 		{[]interface{}{"foo", "bar"}, nil},
 		{[]interface{}{cb}, map[string]Path{"0": {0}}},
+		{[]interface{}{cb, "foo", cb}, map[string]Path{"0": {0}, "1": {2}}},
 		{[]interface{}{"foo", "bar", cb}, map[string]Path{"0": {2}}},
 		{[]interface{}{"foo", []interface{}{"bar", cb}}, map[string]Path{"0": {1, 1}}},
+		{[...]interface{}{"foo", cb, cb}, map[string]Path{"0": {1}, "1": {2}}},
 		{map[string]interface{}{"foo": 1, "bar": 2}, nil},
 		{map[string]interface{}{"foo": 1, "bar": 2, "cb": cb}, map[string]Path{"0": {"cb"}}},
-		{T{1, 2, cb, cb, nil}, map[string]Path{
-			"0": {"c"},
-			"1": {"f1"},
+		{T{privT{0, cb, cb}, 1, 2, cb, cb, nil}, map[string]Path{
+			"0": {"embedB"},
+			"1": {"c"},
+			"2": {"f1"},
 		}},
-		{T{1, 2, cb, cb, &T{C: cb, d: cb}}, map[string]Path{
+		{T{A: 1, b: 2, C: cb, d: cb, E: &T{C: cb, d: cb}}, map[string]Path{
 			"0": {"c"},
 			"1": {"E", "c"},
 			"2": {"E", "f1"},
@@ -48,10 +51,17 @@ func TestScrub(t *testing.T) {
 	}
 }
 
+type privT struct {
+	A int
+	B Function `json:"embedB"`
+	F Function `dnode:"-"`
+}
+
 type T struct {
+	privT
 	A int
 	b int
-	C Function `json:"c"`
+	C Function `json:"c,omitempty"`
 	d Function
 	E *T
 }


### PR DESCRIPTION
Go 1.6 introduced a breaking change in "reflect" package(golang issue #12367).
This broke dnode.Scrubber.Scrub method that was using reflect.Value.Interface
method to collect callbacks. Since go1.6 you cannot get an interface to private
embedded structs so, if you passed embedded struct to Scrub method, it would
panic.

This commit refactors Scrub method and makes it valid in >=go1.6.

Additionally, there is a minor fix which discards JSON field tag options when
they are provided.