### PR TITLE
systeminfo: add windows implementation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,8 @@ install:
 
 build_script:
  - go build ./...
+ - go test -v -race ./dnode
+ - go test -v -race ./systeminfo
  # - go test -v -race ./...
 
 test: off

--- a/dnode/scrubber.go
+++ b/dnode/scrubber.go
@@ -3,13 +3,13 @@ package dnode
 import "sync"
 
 type Scrubber struct {
-	// Reference to sent callbacks are saved in this map.
-	callbacks  map[uint64]func(*Partial)
-	sync.Mutex // protects
-
 	// Next callback number.
-	// Incremented atomically by registerCallback().
+	// Incremented atomically by register().
 	seq uint64
+
+	// Reference to sent callbacks are saved in this map.
+	sync.Mutex // protects
+	callbacks  map[uint64]func(*Partial)
 }
 
 // New returns a pointer to a new Scrubber.

--- a/systeminfo/systeminfo_test.go
+++ b/systeminfo/systeminfo_test.go
@@ -5,8 +5,7 @@ import "testing"
 func TestInfo(t *testing.T) {
 	i, err := New()
 	if err != nil {
-		t.Errorf(err.Error())
-		return
+		t.Fatalf("want err == nil; got %v", err)
 	}
 
 	t.Logf("info: %+v\n", i)

--- a/systeminfo/systeminfo_windows.go
+++ b/systeminfo/systeminfo_windows.go
@@ -56,7 +56,7 @@ func memoryStats() (*memory, error) {
 		return nil, err
 	}
 
-	// memoryStats functions from other platforms return disk usage in bytes.
+	// memoryStats functions from other platforms return memory usage in bytes.
 	return &memory{
 		Usage: mstat.totalPhys - mstat.availPhys,
 		Total: mstat.totalPhys,

--- a/systeminfo/systeminfo_windows.go
+++ b/systeminfo/systeminfo_windows.go
@@ -1,15 +1,65 @@
 package systeminfo
 
 import (
-	"errors"
+	"syscall"
+	"unsafe"
 )
 
-var errNotImplemented = errors.New("not implemented on windows")
+var (
+	modkernel32 = syscall.NewLazyDLL("kernel32.dll")
 
+	procGetDiskFreeSpaceExW  = modkernel32.NewProc("GetDiskFreeSpaceExW")
+	procGlobalMemoryStatusEx = modkernel32.NewProc("GlobalMemoryStatusEx")
+)
+
+// diskStats returns information about the amount of space that is available on
+// a current disk volume for the user who calls this function.
 func diskStats() (*disk, error) {
-	return nil, errNotImplemented
+	var (
+		freeBytes  uint64 = 0
+		totalBytes uint64 = 0
+	)
+
+	// windows sets return value to 0 when function fails.
+	ret, _, err := procGetDiskFreeSpaceExW.Call(
+		0,
+		uintptr(unsafe.Pointer(&freeBytes)),
+		uintptr(unsafe.Pointer(&totalBytes)),
+		0,
+	)
+	if ret == 0 {
+		return nil, err
+	}
+
+	// diskStats functions from other platforms return disk usage in kiB.
+	return &disk{
+		Usage: (totalBytes - freeBytes) / 1024,
+		Total: totalBytes / 1024,
+	}, nil
 }
 
+// memoryStatus retrieves information about the system's current usage of
+// physical memory.
 func memoryStats() (*memory, error) {
-	return nil, errNotImplemented
+	mstat := struct {
+		size      uint32
+		_         uint32
+		totalPhys uint64
+		availPhys uint64
+		_         [5]uint64
+	}{}
+
+	// windows sets return value to 0 when function fails.
+	mstat.size = uint32(unsafe.Sizeof(mstat))
+	ret, _, err := procGlobalMemoryStatusEx.Call(uintptr(unsafe.Pointer(&mstat)))
+	if ret == 0 {
+		return nil, err
+	}
+
+	// memoryStats functions from other platforms return disk usage in bytes.
+	return &memory{
+		Usage: mstat.totalPhys - mstat.availPhys,
+		Total: mstat.totalPhys,
+	}, nil
+
 }


### PR DESCRIPTION
systeminfo package is implemented in all major platforms except Windows. This PR fixes this.