### PR TITLE
kite: make consecutive dials work

### DIFF
--- a/bug_test.go
+++ b/bug_test.go
@@ -1,0 +1,55 @@
+package kite_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/koding/kite"
+)
+
+func TestKite_SeparateKiteClient(t *testing.T) {
+	esrv := kite.New("echo-server", "0.0.0")
+	esrv.Config.DisableAuthentication = true
+	esrv.HandleFunc("echo", func(r *kite.Request) (interface{}, error) {
+		var arg string
+
+		if err := r.Args.One().Unmarshal(&arg); err != nil {
+			return nil, err
+		}
+
+		if arg == "" {
+			return nil, errors.New("arg is empty")
+		}
+
+		return arg, nil
+	})
+
+	ts := httptest.NewServer(esrv)
+	ecli := kite.New("echo-client", "0.0.0")
+
+	esrv.SetLogLevel(kite.DEBUG)
+	ecli.SetLogLevel(kite.DEBUG)
+
+	c := ecli.NewClient(fmt.Sprintf("%s/kite", ts.URL))
+
+	if err := c.Dial(); err != nil {
+		t.Fatalf("dialing echo-server kite error: %s", err)
+	}
+
+	resp, err := c.Tell("echo", "Hello world!")
+	if err != nil {
+		t.Fatalf("Tell()=%s", err)
+	}
+
+	var reply string
+
+	if err := resp.Unmarshal(&reply); err != nil {
+		t.Fatalf("Unmarshal()=%s", err)
+	}
+
+	if reply != "Hello world!" {
+		t.Fatalf(`got %q, want "Hello world!"`, reply)
+	}
+}

--- a/bug_test.go
+++ b/bug_test.go
@@ -9,9 +9,13 @@ import (
 	"github.com/koding/kite"
 )
 
-func TestKite_SeparateKiteClient(t *testing.T) {
+func TestKite_MultipleDial(t *testing.T) {
 	esrv := kite.New("echo-server", "0.0.0")
 	esrv.Config.DisableAuthentication = true
+	if err := esrv.Config.ReadEnvironmentVariables(); err != nil {
+		t.Fatal(err)
+	}
+
 	esrv.HandleFunc("echo", func(r *kite.Request) (interface{}, error) {
 		var arg string
 
@@ -28,11 +32,18 @@ func TestKite_SeparateKiteClient(t *testing.T) {
 
 	ts := httptest.NewServer(esrv)
 	ecli := kite.New("echo-client", "0.0.0")
+	if err := ecli.Config.ReadEnvironmentVariables(); err != nil {
+		t.Fatal(err)
+	}
 
 	esrv.SetLogLevel(kite.DEBUG)
 	ecli.SetLogLevel(kite.DEBUG)
 
 	c := ecli.NewClient(fmt.Sprintf("%s/kite", ts.URL))
+
+	if err := c.Dial(); err != nil {
+		t.Fatalf("dialing echo-server kite error: %s", err)
+	}
 
 	if err := c.Dial(); err != nil {
 		t.Fatalf("dialing echo-server kite error: %s", err)

--- a/client.go
+++ b/client.go
@@ -481,7 +481,7 @@ func (c *Client) sendHub() {
 				// And get rid of the timeout workaround.
 				c.LocalKite.Log.Error("error sending %q: %s", msg, err)
 
-				if err == sockjsclient.ErrSessionClosed || strings.Contains(err.Error(), errClosing) {
+				if err == sockjsclient.ErrSessionClosed {
 					return
 				}
 			}

--- a/server.go
+++ b/server.go
@@ -13,11 +13,6 @@ import (
 	"sync"
 )
 
-// An error string equivalent to net.errClosing for using with http.Serve()
-// during a graceful exit. Needed to declare here again because it is not
-// exported by "net" package.
-const errClosing = "use of closed network connection"
-
 // Run is a blocking method. It runs the kite server and then accepts requests
 // asynchronously. It supports graceful restart via SIGUSR2.
 func (k *Kite) Run() {
@@ -25,6 +20,11 @@ func (k *Kite) Run() {
 		fmt.Println(k.Kite().Version)
 		os.Exit(0)
 	}
+
+	// An error string equivalent to net.errClosing for using with http.Serve()
+	// during a graceful exit. Needed to declare here again because it is not
+	// exported by "net" package.
+	const errClosing = "use of closed network connection"
 
 	err := k.listenAndServe()
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -13,6 +13,11 @@ import (
 	"sync"
 )
 
+// An error string equivalent to net.errClosing for using with http.Serve()
+// during a graceful exit. Needed to declare here again because it is not
+// exported by "net" package.
+const errClosing = "use of closed network connection"
+
 // Run is a blocking method. It runs the kite server and then accepts requests
 // asynchronously. It supports graceful restart via SIGUSR2.
 func (k *Kite) Run() {
@@ -20,11 +25,6 @@ func (k *Kite) Run() {
 		fmt.Println(k.Kite().Version)
 		os.Exit(0)
 	}
-
-	// An error string equivalent to net.errClosing for using with http.Serve()
-	// during a graceful exit. Needed to declare here again because it is not
-	// exported by "net" package.
-	const errClosing = "use of closed network connection"
 
 	err := k.listenAndServe()
 	if err != nil {


### PR DESCRIPTION
We rely on this behaviour in one of our internal tests.

There's still room for further improvement by merging runloop and sendHub into one control goroutine, thus making the session state easier to control.