### PR TITLE
kite: always use UTC timezone for tokens

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -54,7 +54,7 @@ type Config struct {
 	// If nil, the default audience verify function is used which
 	// expects the aud to be a kite path that matches the username,
 	// environment and name of the client.
-	VerifyAudiencefunc func(client *protocol.Kite, aud string) error
+	VerifyAudienceFunc func(client *protocol.Kite, aud string) error
 
 	KontrolURL  string
 	KontrolKey  string

--- a/kite.go
+++ b/kite.go
@@ -34,6 +34,10 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("kite: cannot get hostname: %s", err.Error()))
 	}
+
+	jwt.TimeFunc = func() time.Time {
+		return time.Now().UTC()
+	}
 }
 
 // Kite defines a single process that enables distributed service messaging

--- a/request.go
+++ b/request.go
@@ -314,7 +314,7 @@ func (k *Kite) verifyInit() {
 		k.verifyFunc = k.selfVerify
 	}
 
-	k.verifyAudienceFunc = k.Config.VerifyAudiencefunc
+	k.verifyAudienceFunc = k.Config.VerifyAudienceFunc
 
 	if k.verifyAudienceFunc == nil {
 		k.verifyAudienceFunc = k.verifyAudience


### PR DESCRIPTION
Fixes:

```
2016-07-04 12:05:22 [klient] ERROR    Error in token. Token will not be renewed when it expires: Cannot parse token: Token used before issued
```

When klient and kontrol were in different timezones and their diff > leeway (by default always).

jwt-go 2.0 did use local time as does version 3.0, so renewing either did not worked at all or the tokens started to be validated right now - I have did not dig that deep.