### PR TITLE
kite/client: make callback execution synchronous

### DIFF
--- a/heartbeat.go
+++ b/heartbeat.go
@@ -52,7 +52,7 @@ func newHeartbeatReq(r *Request) (*heartbeatReq, error) {
 func (k *Kite) client() *http.Client {
 	return (&sockjsclient.DialOptions{
 		ClientFunc: k.ClientFunc,
-		Timeout:    8 * time.Second,
+		Timeout:    10 * time.Second,
 	}).Client()
 }
 

--- a/kontrol/kontrol.go
+++ b/kontrol/kontrol.go
@@ -30,7 +30,7 @@ var (
 
 	// TokenLeeway - implementers MAY provide for some small leeway, usually
 	// no more than a few minutes, to account for clock skew.
-	TokenLeeway = 1 * time.Minute
+	TokenLeeway = 5 * time.Minute
 
 	// DefaultPort is a default kite port value.
 	DefaultPort = 4000
@@ -363,7 +363,7 @@ func (k *Kontrol) registerUser(username, publicKey, privateKey string) (kiteKey 
 		StandardClaims: jwt.StandardClaims{
 			Issuer:   k.Kite.Kite().Username,
 			Subject:  username,
-			IssuedAt: time.Now().UTC().Unix(),
+			IssuedAt: time.Now().Add(-k.tokenLeeway()).UTC().Unix(),
 			Id:       uuid.NewV4().String(),
 		},
 		KontrolURL: k.Kite.Config.KontrolURL,
@@ -531,8 +531,8 @@ func (k *Kontrol) generateToken(aud, username, issuer string, kp *KeyPair) (stri
 			Issuer:    issuer,
 			Subject:   username,
 			Audience:  aud,
-			ExpiresAt: now.Add(k.tokenTTL()).Add(k.tokenLeeway()).Unix(),
-			IssuedAt:  now.Unix(),
+			ExpiresAt: now.Add(k.tokenTTL()).Add(k.tokenLeeway()).UTC().Unix(),
+			IssuedAt:  now.Add(-k.tokenLeeway()).UTC().Unix(),
 			Id:        uuid.NewV4().String(),
 		},
 	}


### PR DESCRIPTION
deps: https://github.com/koding/kite/pull/171

The default behaviour for go1.4 scheduler is to execute incoming
callback in order they were received. That applies to small group of
short-lived callbacks that don't do any I/O.

go1.5+ scheduler is more reentrant, which makes callback execution
out-of-order. This breaks existing code that relies on go1.4 scheduler
behaviour.

This PR adds ConcurrentCallbacks field to client which is false by
default to restore go1.4 behaviour.

If you rely on your callbacks being done asynchronously (e.g. you're
doing heavy computations in them) set ConcurrentCallbacks to true
for each your *kite.Client value.