### PR TITLE
kite: add ID for every request / add final handlers

### DIFF
--- a/kite.go
+++ b/kite.go
@@ -71,6 +71,7 @@ type Kite struct {
 	handlers     map[string]*Method // method map for exported methods
 	preHandlers  []Handler          // a list of handlers that are executed before any handler
 	postHandlers []Handler          // a list of handlers that are executed after any handler
+	finalFuncs   []FinalFunc        // a list of funcs executed after any handler regardless of the error
 
 	// MethodHandling defines how the kite is returning the response for
 	// multiple handlers

--- a/method_test.go
+++ b/method_test.go
@@ -2,6 +2,7 @@ package kite
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -160,7 +161,7 @@ func TestMethod_Error(t *testing.T) {
 		t.Fatal("PreHandle returns an error, however error is non-nil.")
 	}
 
-	if err.Error() != testError.Error() {
+	if !strings.HasPrefix(err.Error(), testError.Error()) {
 		t.Errorf("Error should be '%v', got '%v'", testError, err)
 	}
 }

--- a/request.go
+++ b/request.go
@@ -12,28 +12,32 @@ import (
 	"github.com/koding/kite/kitekey"
 	"github.com/koding/kite/protocol"
 	"github.com/koding/kite/sockjsclient"
+	"github.com/koding/kite/utils"
 )
 
 // Request contains information about the incoming request.
 type Request struct {
-	// Method defines the method name which is invoked by the incoming request
+	// ID is an unique string, which may be used for tracing the request.
+	ID string
+
+	// Method defines the method name which is invoked by the incoming request.
 	Method string
-
-	// Args defines the incoming arguments for the given method
-	Args *dnode.Partial
-
-	// LocalKite defines a context for the local kite
-	LocalKite *Kite
-
-	// Client defines a context for the remote kite
-	Client *Client
 
 	// Username defines the username which the incoming request is bound to.
 	// This is authenticated and validated if authentication is enabled.
 	Username string
 
+	// Args defines the incoming arguments for the given method.
+	Args *dnode.Partial
+
+	// LocalKite defines a context for the local kite.
+	LocalKite *Kite
+
+	// Client defines a context for the remote kite.
+	Client *Client
+
 	// Auth stores the authentication information for the incoming request and
-	// the type of authentication. This is not used when authentication is disabled
+	// the type of authentication. This is not used when authentication is disabled.
 	Auth *Auth
 
 	// Context holds a context that used by the current ServeKite handler. Any
@@ -138,6 +142,7 @@ func (c *Client) newRequest(method string, args *dnode.Partial) (*Request, func(
 	}
 
 	request := &Request{
+		ID:        utils.RandomString(16),
 		Method:    method,
 		Args:      options.WithArgs,
 		LocalKite: c.LocalKite,

--- a/request.go
+++ b/request.go
@@ -89,6 +89,7 @@ func (c *Client) runMethod(method *Method, args *dnode.Partial) {
 	if !method.initialized {
 		method.preHandlers = append(method.preHandlers, c.LocalKite.preHandlers...)
 		method.postHandlers = append(method.postHandlers, c.LocalKite.postHandlers...)
+		method.finalFuncs = append(method.finalFuncs, c.LocalKite.finalFuncs...)
 		method.initialized = true
 	}
 	method.mu.Unlock()

--- a/sockjsclient/xhr.go
+++ b/sockjsclient/xhr.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"sync"
+
+	"github.com/koding/kite/utils"
 )
 
 // the implementation of New() doesn't have any error to be returned yet it
@@ -38,7 +40,7 @@ func NewXHRSession(opts *DialOptions) (*XHRSession, error) {
 
 	// following /server_id/session_id should always be the same for every session
 	serverID := threeDigits()
-	sessionID := randomStringLength(20)
+	sessionID := utils.RandomString(20)
 	sessionURL := opts.BaseURL + "/" + serverID + "/" + sessionID
 
 	// start the initial session handshake

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,9 +1,49 @@
 package utils
 
 import (
+	crand "crypto/rand"
+	"encoding/hex"
+	"math/rand"
 	"net"
+	"os"
 	"strconv"
+	"sync"
+	"time"
 )
+
+// globalRand is copied here explicitely to no seed globalRand from math/rand
+// and affect its state.
+var globalRand = rand.New(&lockedSource{src: rand.NewSource(time.Now().UnixNano() + int64(os.Getpid()))})
+
+type lockedSource struct {
+	lk  sync.Mutex
+	src rand.Source
+}
+
+func (r *lockedSource) Int63() (n int64) {
+	r.lk.Lock()
+	n = r.src.Int63()
+	r.lk.Unlock()
+	return
+}
+
+func (r *lockedSource) Seed(seed int64) {
+	r.lk.Lock()
+	r.src.Seed(seed)
+	r.lk.Unlock()
+}
+
+// Int31n returns a pseudo-random int32 in range [0, n).
+func Int31n(n int32) int32 {
+	return globalRand.Int31n(n)
+}
+
+// RandomString returns random string read from crypto/rand.
+func RandomString(n int) string {
+	p := make([]byte, n/2+1)
+	crand.Read(p)
+	return hex.EncodeToString(p)[:n]
+}
 
 // RandomPort() returns a random port to be used with net.Listen(). It's an
 // helper function to register to kontrol before binding to a port. Note that


### PR DESCRIPTION
Hey @cihangir!

The purpose of this PR is to:

- make Client mark each request with unique ID
- add FinalFunc to Client, which purpose is roughly the same as PostHandler, with the only difference it is executed also on failures and it's capable of overwriting / decorating handler's response

The above extensions to kite are needed to extend per-request logging for klient kite.

Please take a look.