### PR TITLE
kite: don't leak sendHub goroutine when client's readLoop ends

### DIFF
--- a/kite.go
+++ b/kite.go
@@ -273,6 +273,7 @@ func (k *Kite) sockjsHandler(session sockjs.Session) {
 	// This Client also handles the connected client.
 	// Since both sides can send/receive messages the client code is reused here.
 	c := k.NewClient("")
+	defer c.Close()
 
 	c.setSession(session)
 	c.wg.Add(1)


### PR DESCRIPTION
`sockjsHandler` creates a new `kite.Client` object for each `sockjs.Session`. Handler and session end their life when blocking `readLoop()` method returns. This means that created `kite.Client` is no longer needed. However, it can't be GC because `sendHub()` still waits for incoming data from `readLoop()` which, as was written above, already returned. 

This change closes created `kite.Client` when it's no longer needed. Closing it will also stop `sendHub()` go-routine.