### PR TITLE
sockjsclient: do not block on sending do() method Result

### DIFF
--- a/sockjsclient/xhr.go
+++ b/sockjsclient/xhr.go
@@ -256,7 +256,7 @@ type doResult struct {
 }
 
 func (x *XHRSession) do(req *http.Request) <-chan doResult {
-	ch := make(chan doResult)
+	ch := make(chan doResult, 1)
 
 	go func() {
 		var res doResult


### PR DESCRIPTION
when the XHR session is closed, there is no way to drain `<-chan doResult` created by `do()`
[method](https://github.com/koding/kite/compare/xhr_session_leak_fix?expand=1#diff-531282dec6b6ed573b67713e0de77f94R113) because `Recv()` internal loop is already aborted.

This PR makes returned `doResult` channel buffered, thus, it will prevent go-routine leaks after session is closed.