### PR TITLE
kite: improve client/server connection configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: false
 go:
   - 1.8
 install:
-  - rm -rf $GOPATH/src/gopkg.in/igm/sockjs-go.v2
-  - git clone https://github.com/igm/sockjs-go $GOPATH/src/gopkg.in/igm/sockjs-go.v2
   - go get -d -v -t ./...
 script:
   - export GOMAXPROCS=$(nproc)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: go
 sudo: false
 go:
-  - 1.7.4
-  - tip
+  - 1.8
 install:
-  - go get -d -v -t ./...
   - rm -rf $GOPATH/src/gopkg.in/igm/sockjs-go.v2
-  - git clone git@github.com:igm/sockjs-go $GOPATH/src/gopkg.in/igm/sockjs-go.v2
+  - git clone https://github.com/igm/sockjs-go $GOPATH/src/gopkg.in/igm/sockjs-go.v2
+  - go get -d -v -t ./...
 script:
   - export GOMAXPROCS=$(nproc)
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ go:
   - tip
 install:
   - go get -d -v -t ./...
+  - rm -rf $GOPATH/src/gopkg.in/igm/sockjs-go.v2
+  - git clone git@github.com:igm/sockjs-go $GOPATH/src/gopkg.in/igm/sockjs-go.v2
 script:
   - export GOMAXPROCS=$(nproc)
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 sudo: false
 go:
+  - 1.7.5
   - 1.8
 install:
   - go get -d -v -t ./...

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,8 @@ environment:
 install:
  - go version
  - go get -v -t ./...
+ - rmdir %GOPATH%\src\gopkg.in\igm\sockjs-go.v2 /s /q
+ - git clone git@github.com:igm/sockjs-go %GOPATH%\src\gopkg.in\igm\sockjs-go.v2
 
 build_script:
  - go build ./...

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,10 +17,6 @@ install:
  - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-amd64.zip
  - 7z x go%GOVERSION%.windows-amd64.zip -y -oC:\ > NUL
 
- # update sockjs-go
- - rmdir %GOPATH%\src\gopkg.in\igm\sockjs-go.v2 /s /q
- - git clone https://github.com/igm/sockjs-go %GOPATH%\src\gopkg.in\igm\sockjs-go.v2
-
  - go get -v -t ./...
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,13 +7,21 @@ clone_folder: c:\projects\src\github.com\koding\kite
 environment:
  PATH: c:\projects\bin;%PATH%
  GOPATH: c:\projects
- NOTIFY_TIMEOUT: 5s
+ GOVERSION: 1.8
 
 install:
  - go version
- - go get -v -t ./...
+
+ # update Go
+ - rmdir c:\go /s /q
+ - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-amd64.zip
+ - 7z x go%GOVERSION%.windows-amd64.zip -y -oC:\ > NUL
+
+ # update sockjs-go
  - rmdir %GOPATH%\src\gopkg.in\igm\sockjs-go.v2 /s /q
- - git clone git@github.com:igm/sockjs-go %GOPATH%\src\gopkg.in\igm\sockjs-go.v2
+ - git clone https://github.com/igm/sockjs-go %GOPATH%\src\gopkg.in\igm\sockjs-go.v2
+
+ - go get -v -t ./...
 
 build_script:
  - go build ./...

--- a/client.go
+++ b/client.go
@@ -245,14 +245,6 @@ func (c *Client) authCopy() *Auth {
 }
 
 func (c *Client) dial(timeout time.Duration) (err error) {
-	if c.ReadBufferSize == 0 {
-		c.ReadBufferSize = 4096
-	}
-
-	if c.WriteBufferSize == 0 {
-		c.WriteBufferSize = 4096
-	}
-
 	opts := &sockjsclient.DialOptions{
 		BaseURL:         c.URL,
 		ReadBufferSize:  c.ReadBufferSize,

--- a/client.go
+++ b/client.go
@@ -11,12 +11,13 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cenkalti/backoff"
 	"github.com/koding/kite/config"
 	"github.com/koding/kite/dnode"
 	"github.com/koding/kite/protocol"
 	"github.com/koding/kite/sockjsclient"
-	"gopkg.in/igm/sockjs-go.v2/sockjs"
+
+	"github.com/cenkalti/backoff"
+	"github.com/igm/sockjs-go/sockjs"
 )
 
 var forever = backoff.NewExponentialBackOff()

--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/websocket"
-	"gopkg.in/igm/sockjs-go.v2/sockjs"
+	"github.com/igm/sockjs-go/sockjs"
 )
 
 // the implementation of New() doesn't have any error to be returned yet it

--- a/config/config.go
+++ b/config/config.go
@@ -250,14 +250,22 @@ func (c *Config) ReadToken(key *jwt.Token) error {
 
 // Copy returns a new copy of the config object.
 func (c *Config) Copy() *Config {
-	copy := *DefaultConfig
-	xhr := *copy.XHR
-	client := *copy.Client
-	ws := *copy.Websocket
+	copy := *c
 
-	copy.XHR = &xhr
-	copy.Client = &client
-	copy.Websocket = &ws
+	if c.XHR != nil {
+		xhr := *copy.XHR
+		copy.XHR = &xhr
+	}
+
+	if c.Client != nil {
+		client := *copy.Client
+		copy.Client = &client
+	}
+
+	if c.Websocket != nil {
+		ws := *copy.Websocket
+		copy.Websocket = &ws
+	}
 
 	return &copy
 }

--- a/config/config.go
+++ b/config/config.go
@@ -4,30 +4,38 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/cookiejar"
 	"os"
 	"strconv"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
 	"github.com/koding/kite/kitekey"
 	"github.com/koding/kite/protocol"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/gorilla/websocket"
+	"gopkg.in/igm/sockjs-go.v2/sockjs"
 )
+
+// the implementation of New() doesn't have any error to be returned yet it
+// returns, so it's totally safe to neglect the error
+var CookieJar, _ = cookiejar.New(nil)
 
 // Options is passed to kite.New when creating new instance.
 type Config struct {
 	// Options for Kite
-	Username              string
-	Environment           string
-	Region                string
-	Id                    string
-	KiteKey               string
-	DisableAuthentication bool
-	DisableConcurrency    bool
-	Transport             Transport
+	Username              string    // Username to set when registering to Kontrol.
+	Environment           string    // Kite environment to set when registering to Kontrol.
+	Region                string    // Kite region to set when registering to Kontrol.
+	Id                    string    // Kite ID to use when registering to Kontrol.
+	KiteKey               string    // The kite.key value to use for "kiteKey" authentication.
+	DisableAuthentication bool      // Do not require authentication for requests.
+	DisableConcurrency    bool      // Do not process messages concurrently.
+	Transport             Transport // SockJS transport to use.
 
-	// Options for Server
-	IP   string
-	Port int
+	IP   string // IP of the kite server.
+	Port int    // Port number of the kite server.
 
 	// VerifyFunc is used to verify the public key of the signed token.
 	//
@@ -56,6 +64,26 @@ type Config struct {
 	// environment and name of the client.
 	VerifyAudienceFunc func(client *protocol.Kite, aud string) error
 
+	// SockJS server / client connection configuration details.
+
+	// XHR is a HTTP client used for polling on responses for a XHR transport.
+	//
+	// Required.
+	XHR *http.Client
+
+	// Websocket is used for creating a client for a websocket transport.
+	//
+	// If custom one is used, ensure any complemenrary field is also
+	// set in sockjs.WebSocketUpgrader value (for server connections).
+	//
+	// Required.
+	Websocket *websocket.Dialer
+
+	// SockJS are used to configure SockJS handler.
+	//
+	// Required.
+	SockJS *sockjs.Options
+
 	KontrolURL  string
 	KontrolKey  string
 	KontrolUser string
@@ -69,13 +97,30 @@ var DefaultConfig = &Config{
 	IP:          "0.0.0.0",
 	Port:        0,
 	Transport:   WebSocket,
+	XHR: &http.Client{
+		// TODO(rjeczalik): make XHR handler timeout if polling on body
+		// is idle > timeout. Timing out after 10s is a bad idea when
+		// the connection is active.
+		// Timeout: 10 * time.Second,
+		Jar: CookieJar,
+	},
+	Websocket: &websocket.Dialer{
+		HandshakeTimeout: 15 * time.Second,
+		Jar:              CookieJar,
+	},
+	SockJS: &sockjs.Options{
+		Websocket:       sockjs.DefaultOptions.Websocket,
+		JSessionID:      sockjs.DefaultOptions.JSessionID,
+		SockJSURL:       sockjs.DefaultOptions.SockJSURL,
+		HeartbeatDelay:  10 * time.Second, // better fit for AWS ELB; empirically picked
+		DisconnectDelay: 10 * time.Second, // >= XHR poll interval
+		ResponseLimit:   sockjs.DefaultOptions.ResponseLimit,
+	},
 }
 
 // New returns a new Config initialized with defaults.
 func New() *Config {
-	c := new(Config)
-	*c = *DefaultConfig
-	return c
+	return DefaultConfig.Copy()
 }
 
 // NewFromKiteKey parses the given kite key file and gives a new Config value.
@@ -91,6 +136,26 @@ func NewFromKiteKey(file string) (*Config, error) {
 	}
 
 	return &c, nil
+}
+
+func Get() (*Config, error) {
+	c := New()
+	if err := c.ReadKiteKey(); err != nil {
+		return nil, err
+	}
+	if err := c.ReadEnvironmentVariables(); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func MustGet() *Config {
+	c, err := Get()
+	if err != nil {
+		fmt.Printf("Cannot read kite.key: %s\n", err.Error())
+		os.Exit(1)
+	}
+	return c
 }
 
 func (c *Config) ReadEnvironmentVariables() error {
@@ -136,6 +201,14 @@ func (c *Config) ReadEnvironmentVariables() error {
 		c.VerifyTTL = ttl
 	}
 
+	if timeout, err := time.ParseDuration(os.Getenv("KITE_TIMEOUT")); err == nil {
+		c.XHR.Timeout = timeout
+	}
+
+	if timeout, err := time.ParseDuration(os.Getenv("KITE_HANDSHAKE_TIMEOUT")); err == nil {
+		c.Websocket.HandshakeTimeout = timeout
+	}
+
 	return nil
 }
 
@@ -169,27 +242,12 @@ func (c *Config) ReadToken(key *jwt.Token) error {
 
 // Copy returns a new copy of the config object.
 func (c *Config) Copy() *Config {
-	cloned := new(Config)
-	*cloned = *c
-	return cloned
-}
+	copy := *DefaultConfig
+	xhr := *copy.XHR
+	ws := *copy.Websocket
 
-func Get() (*Config, error) {
-	c := New()
-	if err := c.ReadKiteKey(); err != nil {
-		return nil, err
-	}
-	if err := c.ReadEnvironmentVariables(); err != nil {
-		return nil, err
-	}
-	return c, nil
-}
+	copy.XHR = &xhr
+	copy.Websocket = &ws
 
-func MustGet() *Config {
-	c, err := Get()
-	if err != nil {
-		fmt.Printf("Cannot read kite.key: %s\n", err.Error())
-		os.Exit(1)
-	}
-	return c
+	return &copy
 }

--- a/config/config.go
+++ b/config/config.go
@@ -71,6 +71,10 @@ type Config struct {
 	// Required.
 	XHR *http.Client
 
+	// Client is a HTTP client used for issuing HTTP register request and
+	// HTTP heartbeats.
+	Client *http.Client
+
 	// Websocket is used for creating a client for a websocket transport.
 	//
 	// If custom one is used, ensure any complemenrary field is also
@@ -103,6 +107,10 @@ var DefaultConfig = &Config{
 		// the connection is active.
 		// Timeout: 10 * time.Second,
 		Jar: CookieJar,
+	},
+	Client: &http.Client{
+		Timeout: 20 * time.Second,
+		Jar:     CookieJar,
 	},
 	Websocket: &websocket.Dialer{
 		HandshakeTimeout: 15 * time.Second,
@@ -244,9 +252,11 @@ func (c *Config) ReadToken(key *jwt.Token) error {
 func (c *Config) Copy() *Config {
 	copy := *DefaultConfig
 	xhr := *copy.XHR
+	client := *copy.Client
 	ws := *copy.Websocket
 
 	copy.XHR = &xhr
+	copy.Client = &client
 	copy.Websocket = &ws
 
 	return &copy

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,32 @@
+package config_test
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/koding/kite/config"
+
+	"github.com/igm/sockjs-go/sockjs"
+)
+
+func TestConfigCopy(t *testing.T) {
+	cases := []*config.Config{
+		config.DefaultConfig, {
+			KontrolURL: "https://koding.com/kontrol/kite",
+			Username:   "john",
+		}, {
+			Environment: "aws",
+			XHR:         http.DefaultClient,
+			SockJS:      &sockjs.DefaultOptions,
+		},
+	}
+
+	for _, cas := range cases {
+		copy := cas.Copy()
+
+		if !reflect.DeepEqual(copy, cas) {
+			t.Fatalf("got %#v, want %#v", copy, cas)
+		}
+	}
+}

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cenkalti/backoff"
 	"github.com/koding/kite/protocol"
-	"github.com/koding/kite/sockjsclient"
 )
 
 type heartbeatReq struct {
@@ -48,13 +47,6 @@ func newHeartbeatReq(r *Request) (*heartbeatReq, error) {
 			return ping.Call()
 		},
 	}, nil
-}
-
-func (k *Kite) client() *http.Client {
-	return (&sockjsclient.DialOptions{
-		ClientFunc: k.ClientFunc,
-		Timeout:    10 * time.Second,
-	}).Client()
 }
 
 func (k *Kite) processHeartbeats() {
@@ -152,7 +144,7 @@ func (k *Kite) RegisterHTTP(kiteURL *url.URL) (*registerResult, error) {
 		return nil, err
 	}
 
-	resp, err := k.client().Post(registerURL, "application/json", bytes.NewReader(data))
+	resp, err := k.Config.XHR.Post(registerURL, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +199,7 @@ func (k *Kite) sendHeartbeats(interval time.Duration, kiteURL *url.URL) {
 	heartbeatFunc := func() error {
 		k.Log.Debug("Sending heartbeat to %s", u)
 
-		resp, err := k.client().Get(u.String())
+		resp, err := k.Config.XHR.Get(u.String())
 		if err != nil {
 			return err
 		}

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -144,7 +144,7 @@ func (k *Kite) RegisterHTTP(kiteURL *url.URL) (*registerResult, error) {
 		return nil, err
 	}
 
-	resp, err := k.Config.XHR.Post(registerURL, "application/json", bytes.NewReader(data))
+	resp, err := k.Config.Client.Post(registerURL, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func (k *Kite) sendHeartbeats(interval time.Duration, kiteURL *url.URL) {
 	heartbeatFunc := func() error {
 		k.Log.Debug("Sending heartbeat to %s", u)
 
-		resp, err := k.Config.XHR.Get(u.String())
+		resp, err := k.Config.Client.Get(u.String())
 		if err != nil {
 			return err
 		}

--- a/kite.go
+++ b/kite.go
@@ -17,15 +17,16 @@ import (
 	"sync"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/gorilla/mux"
-	"github.com/koding/cache"
 	"github.com/koding/kite/config"
 	"github.com/koding/kite/kitekey"
 	"github.com/koding/kite/protocol"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/gorilla/mux"
+	"github.com/igm/sockjs-go/sockjs"
+	"github.com/koding/cache"
 	"github.com/koding/kite/sockjsclient"
 	uuid "github.com/satori/go.uuid"
-	"gopkg.in/igm/sockjs-go.v2/sockjs"
 )
 
 var hostname string

--- a/kite.go
+++ b/kite.go
@@ -66,7 +66,7 @@ type Kite struct {
 	// ClientFunc is used as the default value for kite.Client.ClientFunc.
 	// If nil, a default ClientFunc will be used.
 	//
-	// See also: kite.Client.ClientFunc docstring.
+	// Deprecated: Set Config.XHR field instead.
 	ClientFunc func(*sockjsclient.DialOptions) *http.Client
 
 	// Handlers added with Kite.HandleFunc().
@@ -151,10 +151,17 @@ type Kite struct {
 	Id      string // Unique kite instance id
 }
 
-// New creates, initialize and then returns a new Kite instance. Version must
-// be in 3-digit semantic form. Name is important that it's also used to be
-// searched by others.
+// New creates, initializes and then returns a new Kite instance.
+//
+// Version must be in 3-digit semantic form.
+//
+// Name is important that it's also used to be searched by others.
 func New(name, version string) *Kite {
+	return NewWithConfig(name, version, config.New())
+}
+
+// NewWithConfig builds a new kite value for the given configuration.
+func NewWithConfig(name, version string, cfg *config.Config) *Kite {
 	if name == "" {
 		panic("kite: name cannot be empty")
 	}
@@ -174,7 +181,7 @@ func New(name, version string) *Kite {
 	}
 
 	k := &Kite{
-		Config:         config.New(),
+		Config:         cfg,
 		Log:            l,
 		SetLogLevel:    setlevel,
 		Authenticators: make(map[string]func(*Request) error),
@@ -189,13 +196,8 @@ func New(name, version string) *Kite {
 		muxer:          mux.NewRouter(),
 	}
 
-	// We change the heartbeat interval from 25 seconds to 10 seconds. This is
-	// better for environments such as AWS ELB.
-	sockjsOpts := sockjs.DefaultOptions
-	sockjsOpts.HeartbeatDelay = 10 * time.Second
-
 	// All sockjs communication is done through this endpoint..
-	k.muxer.PathPrefix("/kite").Handler(sockjs.NewHandler("/kite", sockjsOpts, k.sockjsHandler))
+	k.muxer.PathPrefix("/kite").Handler(sockjs.NewHandler("/kite", *cfg.SockJS, k.sockjsHandler))
 
 	// Add useful debug logs
 	k.OnConnect(func(c *Client) { k.Log.Debug("New session: %s", c.session.ID()) })

--- a/kite_test.go
+++ b/kite_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/koding/kite/sockjsclient"
 	_ "github.com/koding/kite/testutil"
 
-	"gopkg.in/igm/sockjs-go.v2/sockjs"
+	"github.com/igm/sockjs-go/sockjs"
 )
 
 func init() {

--- a/sockjsclient/export_test.go
+++ b/sockjsclient/export_test.go
@@ -1,0 +1,4 @@
+package sockjsclient
+
+// MakeWebsocketURL exports makeWebsocketURL for a test purposes.
+var MakeWebsocketURL = makeWebsocketURL

--- a/sockjsclient/sockjsclient.go
+++ b/sockjsclient/sockjsclient.go
@@ -18,7 +18,7 @@ import (
 	"github.com/koding/kite/config"
 	"github.com/koding/kite/utils"
 
-	"gopkg.in/igm/sockjs-go.v2/sockjs"
+	"github.com/igm/sockjs-go/sockjs"
 )
 
 // ErrSessionClosed is returned by Send/Recv methods when

--- a/sockjsclient/sockjsclient.go
+++ b/sockjsclient/sockjsclient.go
@@ -8,8 +8,8 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -275,12 +275,7 @@ func makeWebsocketURL(u *url.URL, serverID, sessionID string) *url.URL {
 		}
 	}
 
-	if strings.HasSuffix(u.Path, "/") {
-		u.Path = u.Path + "/"
-	}
-
-	// Add server_id and session_id to the path.
-	u.Path = u.Path + serverID + "/" + sessionID + "/websocket"
+	u.Path = path.Join(u.Path, serverID, sessionID, "websocket")
 
 	return u
 }

--- a/sockjsclient/sockjsclient_test.go
+++ b/sockjsclient/sockjsclient_test.go
@@ -1,0 +1,29 @@
+package sockjsclient_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/koding/kite/sockjsclient"
+)
+
+func TestMakeWebsocketURL(t *testing.T) {
+	cases := map[string]string{
+		"https://koding.com/kloud/kite":             "wss://koding.com:443/kloud/kite/server/session/websocket",
+		"http://127.0.0.1:56789/kite":               "ws://127.0.0.1:56789/kite/server/session/websocket",
+		"http://rjeczalik.koding.team/kontrol/kite": "ws://rjeczalik.koding.team:80/kontrol/kite/server/session/websocket",
+	}
+
+	for cas, want := range cases {
+		u, err := url.Parse(cas)
+		if err != nil {
+			t.Fatalf("%s: Parse()=%s", cas, err)
+		}
+
+		got := sockjsclient.MakeWebsocketURL(u, "server", "session").String()
+
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	}
+}

--- a/sockjsclient/xhr.go
+++ b/sockjsclient/xhr.go
@@ -7,17 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/http/cookiejar"
 	"sync"
 
 	"gopkg.in/igm/sockjs-go.v2/sockjs"
 
+	"github.com/koding/kite/config"
 	"github.com/koding/kite/utils"
 )
-
-// the implementation of New() doesn't have any error to be returned yet it
-// returns, so it's totally safe to neglect the error
-var cookieJar, _ = cookiejar.New(nil)
 
 // XHRSession implements sockjs.Session with XHR transport.
 type XHRSession struct {
@@ -34,19 +30,17 @@ type XHRSession struct {
 
 var _ sockjs.Session = (*XHRSession)(nil)
 
-// NewXHRSession returns a new XHRSession, a SockJS client which supports
-// xhr-polling
-// http://sockjs.github.io/sockjs-protocol/sockjs-protocol-0.3.3.html#section-74
-func NewXHRSession(opts *DialOptions) (*XHRSession, error) {
-	client := opts.Client()
-
+// DialXHR establishes a SockJS session over a XHR connection.
+//
+// Requires cfg.XHR to be a valid client.
+func DialXHR(uri string, cfg *config.Config) (*XHRSession, error) {
 	// following /server_id/session_id should always be the same for every session
 	serverID := threeDigits()
 	sessionID := utils.RandomString(20)
-	sessionURL := opts.BaseURL + "/" + serverID + "/" + sessionID
+	sessionURL := uri + "/" + serverID + "/" + sessionID
 
 	// start the initial session handshake
-	sessionResp, err := client.Post(sessionURL+"/xhr", "text/plain", nil)
+	sessionResp, err := cfg.XHR.Post(sessionURL+"/xhr", "text/plain", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -68,12 +62,24 @@ func NewXHRSession(opts *DialOptions) (*XHRSession, error) {
 	}
 
 	return &XHRSession{
-		client:     client,
+		client:     cfg.XHR,
 		sessionID:  sessionID,
 		sessionURL: sessionURL,
 		state:      sockjs.SessionActive,
 		abort:      make(chan struct{}, 1),
 	}, nil
+}
+
+// NewXHRSession returns a new XHRSession, a SockJS client which supports xhr-polling:
+//
+//   http://sockjs.github.io/sockjs-protocol/sockjs-protocol-0.3.3.html#section-74
+//
+// Deprecated: Use DialXHR instead.
+func NewXHRSession(opts *DialOptions) (*XHRSession, error) {
+	cfg := config.New()
+	cfg.XHR = opts.client()
+
+	return DialXHR(opts.BaseURL, cfg)
 }
 
 func (x *XHRSession) ID() string {
@@ -207,10 +213,7 @@ func (x *XHRSession) Send(frame string) error {
 		return ErrSessionClosed
 	}
 
-	// Need's to be JSON encoded array of string messages (SockJS protocol
-	// requirement)
-	message := []string{frame}
-	body, err := json.Marshal(&message)
+	body, err := json.Marshal([]string{frame})
 	if err != nil {
 		return err
 	}

--- a/sockjsclient/xhr.go
+++ b/sockjsclient/xhr.go
@@ -177,6 +177,21 @@ func (x *XHRSession) handleResp(resp *http.Response) (msg string, again bool, er
 		x.setState(sockjs.SessionActive)
 
 		return "", true, nil
+	case 'm':
+		var message string
+		if err := json.NewDecoder(buf).Decode(&message); err != nil {
+			return "", false, err
+		}
+
+		if message == "" {
+			return "", false, errors.New("unexpected empty message")
+		}
+
+		x.messages = append(x.messages, message)
+
+		message, x.messages = x.messages[0], x.messages[1:]
+
+		return message, false, nil
 	case 'a':
 		// received an array of messages
 		var messages []string

--- a/sockjsclient/xhr.go
+++ b/sockjsclient/xhr.go
@@ -9,10 +9,10 @@ import (
 	"net/http"
 	"sync"
 
-	"gopkg.in/igm/sockjs-go.v2/sockjs"
-
 	"github.com/koding/kite/config"
 	"github.com/koding/kite/utils"
+
+	"github.com/igm/sockjs-go/sockjs"
 )
 
 // XHRSession implements sockjs.Session with XHR transport.

--- a/tunnelproxy/proxy.go
+++ b/tunnelproxy/proxy.go
@@ -12,10 +12,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
 	"github.com/koding/kite"
 	"github.com/koding/kite/config"
-	"gopkg.in/igm/sockjs-go.v2/sockjs"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/igm/sockjs-go/sockjs"
 )
 
 const (

--- a/tunnelproxy/tunnel.go
+++ b/tunnelproxy/tunnel.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"sync"
 
-	"gopkg.in/igm/sockjs-go.v2/sockjs"
+	"github.com/igm/sockjs-go/sockjs"
 )
 
 type Tunnel struct {


### PR DESCRIPTION
This PR reworks connection configuration part of the kite package.

Currently:

1) it is not possible to configure SockJS server handler
2) client can be configured via setting the following fields:
  - (*Kite).ClientFunc
  - (*Client).ClientFunc
  - (*Client).ReadBufferSize
  - (*Client).WriteBufferSize
  - (*DialOptions).ReadBufferSize
  - (*DialOptions).WriteBufferSize
  - (*DialOptions).Timeout

3) it is not possible to configure websocket client (compression, response limit etc.)

This PR unifies the configuration by adding:

1) (*config.Config).SockJS
2) (*config.Config).XHR + external sockjs.WebSocketUpgrader (https://github.com/igm/sockjs-go/pull/56)
3) (*config.Config).Websocket

All the changes are done in a backward-compatible way, with deprecation documentation in appropriate places.

Please take a look.