### PR TITLE
kontrol: add Force parameter to get new token

### DIFF
--- a/kontrol/kontrol_test.go
+++ b/kontrol/kontrol_test.go
@@ -572,7 +572,7 @@ func TestKontrol(t *testing.T) {
 	// Test Kontrol.GetToken
 	// TODO(rjeczalik): rework test to not touch Kontrol internals
 	kon.tokenCacheMu.Lock()
-	kon.tokenCache = make(map[string]string)
+	kon.tokenCache = make(map[string]cachedToken)
 	kon.tokenCacheMu.Unlock()
 
 	_, err = exp2Kite.GetToken(&remoteMathWorker.Kite)
@@ -711,7 +711,7 @@ func TestKontrolMultiKey(t *testing.T) {
 	// Test Kontrol.GetToken
 	// TODO(rjeczalik): rework test to not touch Kontrol internals
 	kon.tokenCacheMu.Lock()
-	kon.tokenCache = make(map[string]string) // empty it
+	kon.tokenCache = make(map[string]cachedToken) // empty it
 	kon.tokenCacheMu.Unlock()
 
 	newToken, err := exp3Kite.GetToken(&remoteMathWorker.Kite)

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -149,6 +149,13 @@ type GetKitesArgs struct {
 	Who           json.RawMessage `json:"who"`
 }
 
+// GetTokenArgs is a request value for the "getToken" kontrol method.
+type GetTokenArgs struct {
+	KontrolQuery // kite to generate a token for
+
+	Force bool `json:"force"` // force creation of a new token
+}
+
 type WhoResult struct {
 	Query *KontrolQuery `json:"query"`
 }


### PR DESCRIPTION
The "getToken" method will always return the same token until
it has expired.

The Force parameter forces Kontrol to generate new token,
even if the old one is not expired, at least from Kontrol's
perspective.