### PR TITLE
kite/client: improve resilience

### DIFF
--- a/client.go
+++ b/client.go
@@ -110,6 +110,10 @@ type Client struct {
 	// is closed but was not dialed
 	closeRenewer chan struct{}
 
+	// interrupt is used to signalise readloop that
+	// session was interrupted.
+	interrupt chan error
+
 	// To syncronize the consumers
 	wg sync.WaitGroup
 
@@ -198,6 +202,7 @@ func (k *Kite) NewClient(remoteURL string) *Client {
 		testHookSetSession: nopSetSession,
 		Concurrent:         true,
 		send:               make(chan *message),
+		interrupt:          make(chan error, 1),
 	}
 
 	k.OnRegister(c.updateAuth)
@@ -388,6 +393,9 @@ func (c *Client) reconnect() bool {
 func (c *Client) readLoop() error {
 	for {
 		p, err := c.receiveData()
+
+		c.LocalKite.Log.Debug("readloop received: %v %v", p, err)
+
 		if err != nil {
 			return err
 		}
@@ -418,19 +426,29 @@ func (c *Client) readLoop() error {
 
 // receiveData reads a message from session.
 func (c *Client) receiveData() ([]byte, error) {
+	type recv struct {
+		msg []byte
+		err error
+	}
+
 	session := c.getSession()
 	if session == nil {
 		return nil, errors.New("not connected")
 	}
 
-	msg, err := session.Recv()
-	if err != nil {
-		c.LocalKite.Log.Debug("Receive err: %s", err)
-	} else {
-		c.LocalKite.Log.Debug("Received : %s", msg)
-	}
+	done := make(chan recv)
 
-	return []byte(msg), err
+	go func() {
+		msg, err := session.Recv()
+		done <- recv{[]byte(msg), err}
+	}()
+
+	select {
+	case r := <-done:
+		return r.msg, r.err
+	case err := <-c.interrupt:
+		return nil, err
+	}
 }
 
 // processMessage processes a single message and calls a handler or callback.
@@ -534,13 +552,19 @@ func (c *Client) sendHub() {
 
 			err := session.Send(string(msg.p))
 			if err != nil {
-				// TODO(rjeczalik): temporary workaround for koding/koding#8711
-				if err != sockjs.ErrSessionNotOpen {
-					c.LocalKite.Log.Error("error sending: %s", err)
-				}
-
 				if msg.errC != nil {
 					msg.errC <- err
+				}
+
+				if sockjsclient.IsSessionClosed(err) {
+					// The readloop may already be interrupted, thus the non-blocking send.
+					select {
+					case c.interrupt <- err:
+					default:
+					}
+
+					c.LocalKite.Log.Error("error sending to %s: %s", session.ID(), err)
+					return
 				}
 			}
 		case <-c.closeChan:

--- a/client.go
+++ b/client.go
@@ -436,7 +436,7 @@ func (c *Client) receiveData() ([]byte, error) {
 		return nil, errors.New("not connected")
 	}
 
-	done := make(chan recv)
+	done := make(chan recv, 1)
 
 	go func() {
 		msg, err := session.Recv()

--- a/client.go
+++ b/client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/koding/kite/sockjsclient"
 
 	"github.com/cenkalti/backoff"
+	"github.com/gorilla/websocket"
 	"github.com/igm/sockjs-go/sockjs"
 )
 
@@ -277,6 +278,13 @@ func (c *Client) dial(timeout time.Duration) (err error) {
 		session, err = sockjsclient.DialWebsocket(c.URL, c.config())
 	case config.XHRPolling:
 		session, err = sockjsclient.DialXHR(c.URL, c.config())
+	case config.Auto:
+		session, err = sockjsclient.DialWebsocket(c.URL, c.config())
+		if err == websocket.ErrBadHandshake {
+			// In cases when kite server is behind a proxy that do
+			// not support websocket connections, fall back to XHR.
+			session, err = sockjsclient.DialXHR(c.URL, c.config())
+		}
 	default:
 		return fmt.Errorf("Connection transport is not known '%v'", transport)
 	}

--- a/client.go
+++ b/client.go
@@ -394,7 +394,7 @@ func (c *Client) readLoop() error {
 	for {
 		p, err := c.receiveData()
 
-		c.LocalKite.Log.Debug("readloop received: %v %v", p, err)
+		c.LocalKite.Log.Debug("readloop received: %s %v", p, err)
 
 		if err != nil {
 			return err

--- a/config/config.go
+++ b/config/config.go
@@ -71,6 +71,18 @@ type Config struct {
 	// Required.
 	XHR *http.Client
 
+	// Timeout specified max time waiting for the following operations to complete:
+	//
+	//   - polling on an XHR connection
+	//   - default timeout for certain kite requests (Kontrol API)
+	//   - HTTP heartbeats and register method
+	//
+	// NOTE: Ensure the Timeout is higher than SockJS.HeartbeatDelay, otherwise
+	// XHR connections may get randomly closed.
+	//
+	// TODO(rjeczalik): Make kite heartbeats configurable as well.
+	Timeout time.Duration
+
 	// Client is a HTTP client used for issuing HTTP register request and
 	// HTTP heartbeats.
 	Client *http.Client
@@ -101,15 +113,12 @@ var DefaultConfig = &Config{
 	IP:          "0.0.0.0",
 	Port:        0,
 	Transport:   Auto,
+	Timeout:     15 * time.Second,
 	XHR: &http.Client{
-		// TODO(rjeczalik): make XHR handler timeout if polling on body
-		// is idle > timeout. Timing out after 10s is a bad idea when
-		// the connection is active.
-		// Timeout: 10 * time.Second,
 		Jar: CookieJar,
 	},
 	Client: &http.Client{
-		Timeout: 20 * time.Second,
+		Timeout: 15 * time.Second,
 		Jar:     CookieJar,
 	},
 	Websocket: &websocket.Dialer{
@@ -121,7 +130,7 @@ var DefaultConfig = &Config{
 		JSessionID:      sockjs.DefaultOptions.JSessionID,
 		SockJSURL:       sockjs.DefaultOptions.SockJSURL,
 		HeartbeatDelay:  10 * time.Second, // better fit for AWS ELB; empirically picked
-		DisconnectDelay: 10 * time.Second, // >= XHR poll interval
+		DisconnectDelay: 10 * time.Second, // >= Timeout
 		ResponseLimit:   sockjs.DefaultOptions.ResponseLimit,
 	},
 }
@@ -210,7 +219,8 @@ func (c *Config) ReadEnvironmentVariables() error {
 	}
 
 	if timeout, err := time.ParseDuration(os.Getenv("KITE_TIMEOUT")); err == nil {
-		c.XHR.Timeout = timeout
+		c.Timeout = timeout
+		c.Client.Timeout = timeout
 	}
 
 	if timeout, err := time.ParseDuration(os.Getenv("KITE_HANDSHAKE_TIMEOUT")); err == nil {

--- a/config/config.go
+++ b/config/config.go
@@ -100,7 +100,7 @@ var DefaultConfig = &Config{
 	Region:      "unknown",
 	IP:          "0.0.0.0",
 	Port:        0,
-	Transport:   WebSocket,
+	Transport:   Auto,
 	XHR: &http.Client{
 		// TODO(rjeczalik): make XHR handler timeout if polling on body
 		// is idle > timeout. Timing out after 10s is a bad idea when

--- a/config/transport.go
+++ b/config/transport.go
@@ -6,6 +6,7 @@ type Transport int
 const (
 	WebSocket = iota
 	XHRPolling
+	Auto
 )
 
 func (t Transport) String() string {
@@ -14,6 +15,8 @@ func (t Transport) String() string {
 		return "WebSocket"
 	case XHRPolling:
 		return "XHRPolling"
+	case Auto:
+		return "auto"
 	default:
 		return "UnkownKiteTransport"
 	}
@@ -22,4 +25,5 @@ func (t Transport) String() string {
 var Transports = map[string]Transport{
 	"WebSocket":  WebSocket,
 	"XHRPolling": XHRPolling,
+	"auto":       Auto,
 }

--- a/kontrol/kontrol_test.go
+++ b/kontrol/kontrol_test.go
@@ -345,7 +345,7 @@ func TestTokenInvalidation(t *testing.T) {
 	}
 
 	if oldToken == token {
-		t.Errorf("want %q == %q", oldToken, token)
+		t.Errorf("want %q != %q", oldToken, token)
 	}
 
 	time.Sleep(time.Millisecond * 700)

--- a/sockjsclient/xhr.go
+++ b/sockjsclient/xhr.go
@@ -379,7 +379,7 @@ func (fr *frameReader) readFrame() {
 		c   byte
 		err error
 	}
-	done := make(chan result)
+	done := make(chan result, 1)
 
 	go func() {
 		c, err := fr.r.ReadByte()

--- a/sockjsclient/xhr_test.go
+++ b/sockjsclient/xhr_test.go
@@ -1,0 +1,93 @@
+package sockjsclient
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net"
+	"testing"
+	"time"
+)
+
+type fakeReader struct {
+	err error
+	p   chan []byte
+}
+
+func (fk *fakeReader) Read(p []byte) (int, error) {
+	q, ok := <-fk.p
+	if !ok {
+		if fk.err == nil {
+			return 0, io.EOF
+		}
+		return 0, fk.err
+	}
+	if len(q) > len(p) {
+		panic(io.ErrShortBuffer)
+	}
+	return copy(p, q), nil
+}
+
+func TestFrameReader(t *testing.T) {
+	const timeout = 100 * time.Millisecond
+
+	var (
+		doWrite = func(fk *fakeReader, p []byte, _ error) {
+			fk.p <- p
+			close(fk.p)
+		}
+		doTimeout = func(fk *fakeReader, p []byte, _ error) {
+			time.AfterFunc(2*timeout, func() {
+				fk.p <- p
+				close(fk.p)
+			})
+		}
+		doError = func(fk *fakeReader, _ []byte, err error) {
+			fk.err = err
+			close(fk.p)
+		}
+	)
+
+	cases := map[string]struct {
+		write func(*fakeReader, []byte, error)
+		p     []byte
+		err   error
+	}{
+		"session open":         {doWrite, []byte{'o'}, nil},
+		"session open timeout": {doTimeout, []byte{'o'}, ErrPollTimeout},
+		"session open error":   {doError, []byte{'o'}, &net.AddrError{}},
+		"message":              {doWrite, []byte(`m"hello world"`), nil},
+		"message timeout":      {doTimeout, []byte(`m"hello world"`), ErrPollTimeout},
+		"message error":        {doError, []byte(`m"hello world"`), &net.AddrError{}},
+	}
+
+	for name, cas := range cases {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			fk := &fakeReader{
+				p: make(chan []byte, 1),
+			}
+
+			fr := &frameReader{
+				r:       bufio.NewReader(fk),
+				timeout: timeout,
+			}
+
+			cas.write(fk, cas.p, cas.err)
+
+			p, err := ioutil.ReadAll(fr)
+			if cas.err != nil {
+				if err != cas.err {
+					t.Fatalf("got %v, want %v", err, cas.err)
+				}
+
+				return
+			}
+
+			if bytes.Compare(p, cas.p) != 0 {
+				t.Fatalf("got %q, want %q", p, cas.p)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR:

- adds config.Auto
- adds config.Config.Timeout
- handles poll timeouts during reading XHR response body
- interrupts readloop (effectively stops session) if send failed due to closed session

Please take a look.