### PR TITLE
config: add Serve field

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/cookiejar"
 	"os"
@@ -13,7 +14,7 @@ import (
 	"github.com/koding/kite/kitekey"
 	"github.com/koding/kite/protocol"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/websocket"
 	"github.com/igm/sockjs-go/sockjs"
 )
@@ -99,6 +100,12 @@ type Config struct {
 	//
 	// Required.
 	SockJS *sockjs.Options
+
+	// Serve is serving HTTP requests using handler on requests
+	// comming from the given listener.
+	//
+	// If Serve is nil, http.Serve is used by default.
+	Serve func(net.Listener, http.Handler) error
 
 	KontrolURL  string
 	KontrolKey  string

--- a/server.go
+++ b/server.go
@@ -91,7 +91,14 @@ func (k *Kite) listenAndServe() error {
 	defer close(k.closeC) // serving is finished, notify waiters.
 	k.Log.Info("Serving...")
 
-	return http.Serve(k.listener, k)
+	return k.serve(k.listener, k)
+}
+
+func (k *Kite) serve(l net.Listener, h http.Handler) error {
+	if k.Config.Serve != nil {
+		return k.Config.Serve(l, h)
+	}
+	return http.Serve(l, h)
 }
 
 // Port returns the TCP port number that the kite listens.


### PR DESCRIPTION
Currently (*kite.Kite).Run() uses default HTTP server for serving
requests. If a custom http.Server (e.g. with adjusted
timeouts etc.) is needed, a Serve field can be used to provide
custom implementation.

In particular this field is needed to disable HTTP2 server for
cmd/tunnelserver in order to fix koding/koding#11269.