### PR TITLE
Fixes breaking change done in net/url

### DIFF
--- a/kontrol/etcd.go
+++ b/kontrol/etcd.go
@@ -33,7 +33,7 @@ type Etcd struct {
 
 func NewEtcd(machines []string, log kite.Logger) *Etcd {
 	if machines == nil || len(machines) == 0 {
-		machines = []string{"127.0.0.1:4001"}
+		machines = []string{"//127.0.0.1:4001"}
 	}
 
 	client := etcd.NewClient(machines)


### PR DESCRIPTION
A change made to the net/url library in go 1.8 causes a panic when
starting kontrol:

panic: parse 127.0.0.1:4001: first path segment in URL cannot contain colon

This is caused by the fact that net/url no longer considers
"127.0.0.1:4001" a valid URL because the specification allows for dots
in the schema-part of the URL.

* https://github.com/golang/go/issues/19297