### PR TITLE
kontrol: Use supported etcd client library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 sudo: false
 go:
-  - 1.7.5
-  - 1.8
+  - 1.8.3
+  - 1.9
 install:
   - go get -d -v -t ./...
 script:

--- a/kontrol/_watcher.go
+++ b/kontrol/_watcher.go
@@ -3,7 +3,7 @@ package kontrol
 import (
 	"errors"
 
-	"github.com/coreos/go-etcd/etcd"
+	etcd "github.com/coreos/etcd/client"
 	"github.com/hashicorp/go-version"
 	"github.com/koding/kite"
 	"github.com/koding/kite/dnode"

--- a/kontrol/node.go
+++ b/kontrol/node.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/coreos/go-etcd/etcd"
+	etcd "github.com/coreos/etcd/client"
 	kontrolprotocol "github.com/koding/kite/kontrol/protocol"
 	"github.com/koding/kite/protocol"
 )


### PR DESCRIPTION
https://github.com/coreos/go-etcd/etcd has been deprecated in favor
of https://github.com/coreos/etcd/client. This patch updates kontrol
to use the supported etcd client library.