### PR TITLE
kite: expose client lifetime information to kite handler

### DIFF
--- a/client.go
+++ b/client.go
@@ -212,7 +212,7 @@ func (k *Kite) NewClient(remoteURL string) *Client {
 		Concurrent:         true,
 		send:               make(chan *message),
 		interrupt:          make(chan error, 1),
-		ctx:                context.TODO(),
+		ctx:                context.Background(),
 		cancel:             func() {},
 	}
 

--- a/examples/math/math-kite/math.go
+++ b/examples/math/math-kite/math.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 
@@ -20,7 +21,7 @@ func main() {
 		resp := "hello from pre handler!"
 
 		// let us return an hello to base square method!
-		r.Context.Set("response", resp)
+		r.Context = context.WithValue(r.Context, "response", resp)
 		return resp, nil
 	})
 
@@ -30,7 +31,7 @@ func main() {
 
 		// Pass the response from the previous square method back to the
 		// client, this is imporant if you use post handler.
-		return r.Context.Get("response")
+		return r.Context.Value("response").(string), nil
 	})
 
 	// Add our handler method, authentication is disabled for this example.

--- a/kite.go
+++ b/kite.go
@@ -283,6 +283,7 @@ func (k *Kite) sockjsHandler(session sockjs.Session) {
 	go c.sendHub()
 
 	k.callOnConnectHandlers(c)
+	c.callOnConnectHandlers()
 
 	// Run after methods are registered and delegate is set
 	c.readLoop()

--- a/kite_test.go
+++ b/kite_test.go
@@ -86,15 +86,10 @@ func TestContext(t *testing.T) {
 	want := []int{1, 2, 3, 4}
 	timeout := time.After(2 * time.Second)
 
-collect:
-	for {
+	for len(got) != len(want) {
 		select {
 		case i := <-ch:
 			got = append(got, i)
-
-			if len(got) == len(want) {
-				break collect
-			}
 		case <-timeout:
 			t.Fatal("timed out collecting checkpoints")
 		}

--- a/kite_test.go
+++ b/kite_test.go
@@ -2,10 +2,12 @@ package kite
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"math"
 	"math/rand"
 	"os"
+	"reflect"
 	"strconv"
 	"sync"
 	"testing"
@@ -20,6 +22,8 @@ import (
 	"github.com/igm/sockjs-go/sockjs"
 )
 
+var timeout = flag.Duration("telltime", 4*time.Second, "Timeout for kite calls.")
+
 func init() {
 	rand.Seed(time.Now().Unix() + int64(os.Getpid()))
 }
@@ -30,6 +34,76 @@ func panicHandler(*Client) {
 
 func panicRegisterHandler(*protocol.RegisterResult) {
 	panic("this panic should be ignored")
+}
+
+func transportFromEnv() config.Transport {
+	env := os.Getenv("KITE_TRANSPORT")
+	tr, ok := config.Transports[env]
+	if env != "" && !ok {
+		panic(fmt.Errorf("transport %q doesn't exists", env))
+	}
+	return tr
+}
+
+func TestContext(t *testing.T) {
+	flag.Parse()
+
+	ch := make(chan int, 4) // checkpoints, to ensure flor of control
+
+	k := New("server", "0.0.1")
+	k.Config.DisableAuthentication = true
+	k.Config.Port = 3333
+	k.Config.Transport = transportFromEnv()
+	k.HandleFunc("longrunning", func(r *Request) (interface{}, error) {
+		ch <- 2
+
+		go func() {
+			<-r.Context.Done()
+			ch <- 4
+			close(ch)
+		}()
+		return nil, nil
+	})
+	go k.Run()
+	<-k.ServerReadyNotify()
+	defer k.Close()
+
+	c := New("client", "0.0.1").NewClient("http://127.0.0.1:3333/kite")
+	if err := c.Dial(); err != nil {
+		t.Fatalf("Dial()=%s", err)
+	}
+
+	ch <- 1
+
+	if _, err := c.TellWithTimeout("longrunning", *timeout); err != nil {
+		t.Fatalf("TellWithTimeout()=%s", err)
+	}
+
+	ch <- 3
+
+	c.Close()
+
+	var got []int
+	timeout := time.After(2 * time.Second)
+
+collect:
+	for {
+		select {
+		case i, ok := <-ch:
+			if !ok {
+				break collect
+			}
+			got = append(got, i)
+		case <-timeout:
+			t.Fatal("timed out collecting checkpoints")
+		}
+	}
+
+	want := []int{1, 2, 3, 4}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v")
+	}
 }
 
 func TestMultiple(t *testing.T) {
@@ -44,15 +118,7 @@ func TestMultiple(t *testing.T) {
 	// ports are starting from 6000 up to 6000 + kiteNumber
 	port := 6000
 
-	var transport config.Transport
-	if transportName := os.Getenv("KITE_TRANSPORT"); transportName != "" {
-		tr, ok := config.Transports[transportName]
-		if !ok {
-			t.Fatalf("transport '%s' doesn't exists", transportName)
-		}
-
-		transport = tr
-	}
+	transport := transportFromEnv()
 
 	for i := 0; i < kiteNumber; i++ {
 		m := New("mathworker"+strconv.Itoa(i), "0.1."+strconv.Itoa(i))

--- a/method_test.go
+++ b/method_test.go
@@ -1,6 +1,7 @@
 package kite
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -172,53 +173,53 @@ func TestMethod_Base(t *testing.T) {
 	k.Config.Port = 10000
 
 	k.PreHandleFunc(func(r *Request) (interface{}, error) {
-		r.Context.Set("pre1", "pre1")
+		r.Context = context.WithValue(r.Context, "pre1", "pre1")
 		return nil, nil
 	})
 
 	k.PreHandleFunc(func(r *Request) (interface{}, error) {
-		res, _ := r.Context.Get("pre1")
+		res, _ := r.Context.Value("pre1").(string)
 		if res != "pre1" {
 			t.Errorf("Context response from previous pre handler should be pre1, got: %v", res)
 		}
 
-		r.Context.Set("pre2", "pre2")
+		r.Context = context.WithValue(r.Context, "pre2", "pre2")
 		return nil, nil
 	})
 
 	k.HandleFunc("foo", func(r *Request) (interface{}, error) {
-		res, _ := r.Context.Get("funcPre1")
+		res, _ := r.Context.Value("funcPre1").(string)
 		if res != "funcPre1" {
 			t.Errorf("Context response from previous pre handler should be funcPre1, got: %v", res)
 		}
 
-		r.Context.Set("handle", "handle")
+		r.Context = context.WithValue(r.Context, "handle", "handle")
 		return "main-response", nil
 	}).PreHandleFunc(func(r *Request) (interface{}, error) {
-		r.Context.Set("funcPre1", "funcPre1")
+		r.Context = context.WithValue(r.Context, "funcPre1", "funcPre1")
 		return "funcPre1", nil
 	}).PostHandleFunc(func(r *Request) (interface{}, error) {
-		res, _ := r.Context.Get("handle")
+		res, _ := r.Context.Value("handle").(string)
 		if res != "handle" {
 			t.Errorf("Context response from previous pre handler should be handle, got: %v", res)
 		}
 
-		r.Context.Set("funcPost1", "funcPost1")
+		r.Context = context.WithValue(r.Context, "funcPost1", "funcPost1")
 		return "funcPost1", nil
 	})
 
 	k.PostHandleFunc(func(r *Request) (interface{}, error) {
-		res, _ := r.Context.Get("funcPost1")
+		res, _ := r.Context.Value("funcPost1").(string)
 		if res != "funcPost1" {
 			t.Errorf("Context response from previous pre handler should be funcPost1, got: %v", res)
 		}
 
-		r.Context.Set("post1", "post1")
+		r.Context = context.WithValue(r.Context, "post1", "post1")
 		return "post1", nil
 	})
 
 	k.PostHandleFunc(func(r *Request) (interface{}, error) {
-		res, _ := r.Context.Get("post1")
+		res, _ := r.Context.Value("post1").(string)
 		if res != "post1" {
 			t.Errorf("Context response from previous pre handler should be post1, got: %v", res)
 		}

--- a/request.go
+++ b/request.go
@@ -154,7 +154,7 @@ func (c *Client) newRequest(method string, args *dnode.Partial) (*Request, func(
 		LocalKite: c.LocalKite,
 		Client:    c,
 		Auth:      options.Auth,
-		Context:   context.TODO(),
+		Context:   c.context(),
 	}
 
 	// Call response callback function, send back our response

--- a/request.go
+++ b/request.go
@@ -1,6 +1,7 @@
 package kite
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"runtime/debug"
@@ -44,7 +45,10 @@ type Request struct {
 	// items added to the Context can be fetched from other handlers in the
 	// chain. This is useful with PreHandle and PostHandle handlers to pass
 	// data between handlers.
-	Context cache.Cache
+	//
+	// The context is canceled when client has disconnected or session
+	// was prematurely terminated.
+	Context context.Context
 }
 
 // Response is the type of the object that is returned from request handlers
@@ -150,7 +154,7 @@ func (c *Client) newRequest(method string, args *dnode.Partial) (*Request, func(
 		LocalKite: c.LocalKite,
 		Client:    c,
 		Auth:      options.Auth,
-		Context:   cache.NewMemory(),
+		Context:   context.TODO(),
 	}
 
 	// Call response callback function, send back our response


### PR DESCRIPTION
There is a common scenario, where a kite handler expects a callback sent from a client, just to start a long-running goroutine and feed information to client via that callback.

We want to have a mean to terminate that long-running goroutine when client disconnect, in order to clean resources.

This PR makes the (*kite.Request).Context a proper context.Context value, which is canceled upon client being disconnected.