### PR TITLE
fix multiple-value in singble value context issue

### DIFF
--- a/kite.go
+++ b/kite.go
@@ -171,7 +171,7 @@ func NewWithConfig(name, version string, cfg *config.Config) *Kite {
 		panic("kite: version must be 3-digits semantic version")
 	}
 
-	kiteID := uuid.NewV4()
+	kiteID, _ := uuid.NewV4()
 
 	l, setlevel := newLogger(name)
 


### PR DESCRIPTION
kite/kite.go:174:22: multiple-value uuid.NewV4() in single-value context